### PR TITLE
Prefer Agent Runners copy and agent contract aliases

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -89,7 +89,7 @@ jobs:
             ACTION_REF="${PR_ACTION_REF:-$GITHUB_SHA}"
           fi
           RUN_MARKER="canary-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          ISSUE_TITLE="Agent runner canary smoke test ${RUN_MARKER}"
+          ISSUE_TITLE="Agent Runners canary smoke test ${RUN_MARKER}"
           DEFAULT_PROMPT="@netlify codex in README.md, replace or add one line exactly: Canary marker: ${RUN_MARKER}. Do not edit other files."
           PROMPT="${REQUESTED_PROMPT:-$DEFAULT_PROMPT}"
           TIMEOUT_SECONDS=$((TIMEOUT_MINUTES * 60))
@@ -121,7 +121,7 @@ jobs:
             echo "Canary workflow already pinned to ${ACTION_REF}."
           else
             git add "$CANARY_WORKFLOW_PATH"
-            git commit -m "chore: pin agent runner canary to ${ACTION_REF}"
+            git commit -m "chore: pin Agent Runners canary to ${ACTION_REF}"
             git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${CANARY_REPO}.git"
             git push origin HEAD:main
           fi
@@ -249,7 +249,7 @@ jobs:
           SIMULATED_FAILURE: ${{ steps.canary.outputs.simulated-failure }}
         run: |
           {
-            echo "## Agent Runner Canary"
+            echo "## Agent Runners Canary"
             echo
             echo "| Field | Value |"
             echo "| --- | --- |"
@@ -297,7 +297,7 @@ jobs:
             --arg simulated_failure "${SIMULATED_FAILURE:-false}" \
             '{
               text: (
-                "Agent Runner canary failed\n" +
+                "Agent Runners canary failed\n" +
                 "Run: " + $run_url + "\n" +
                 "PR: " + $pr_url + "\n" +
                 "Event: " + $event_name + "\n" +

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# Netlify Agent Runner
+# Netlify Agent Runners
 
 > [!NOTE]
 > The action is currently in beta, under active development
 
-A GitHub Action that lets you trigger [Netlify Agents](https://www.netlify.com/products/agents/) directly from GitHub issues and pull requests using `@netlify` mentions.
+A GitHub Action that starts [Netlify Agent Runners](https://www.netlify.com/products/agents/) agent runs directly from GitHub issues and pull requests using `@netlify` mentions.
 
 ## How it works
 
 1. Create an issue or comment on a PR with `@netlify` followed by your prompt
 2. The action picks up the trigger, adds a 👀 reaction, and creates an in-progress status comment
-3. Netlify Agents builds or modifies your site based on the prompt
+3. Netlify Agent Runners creates an agent run to build or modify your site based on the prompt
 4. On completion, the status comment is updated with a screenshot, deploy preview link, and result summary
 5. If triggered from an issue, a PR is automatically created with the changes
 
@@ -22,7 +22,7 @@ A GitHub Action that lets you trigger [Netlify Agents](https://www.netlify.com/p
 @netlify gemini Add a testimonials section
 ```
 
-The default model is `codex`. Specify `claude`, `codex`, or `gemini` after `@netlify` to choose a model.
+The default agent is `codex`. Specify `claude`, `codex`, or `gemini` after `@netlify` to choose an agent.
 
 ## Quick start
 
@@ -46,13 +46,13 @@ Go to **Settings > Secrets and variables > Actions** and add:
 Create `.github/workflows/netlify-agents.yml` in your repository:
 
 ```yaml
-name: Netlify Agents
+name: Netlify Agent Runners
 
 on:
   workflow_dispatch:
     inputs:
       trigger_text:
-        description: 'Prompt for the Netlify Agent'
+        description: 'Prompt for the agent run'
         required: true
         type: string
         default: '@netlify'
@@ -60,8 +60,8 @@ on:
         description: 'Actor triggering the agent'
         required: true
         type: string
-      model:
-        description: 'Model to use (claude, codex, gemini)'
+      agent:
+        description: 'Agent to use (claude, codex, gemini)'
         required: false
         type: string
         default: 'codex'
@@ -114,10 +114,11 @@ Or comment `@netlify make it blue` on an existing PR.
 | `netlify-site-id` | Yes | — | Netlify site ID |
 | `github-token` | No | `github.token` | GitHub token for API calls |
 | `allowed-users` | No | `''` | Comma-separated usernames allowed to trigger (empty = repo collaborators) |
-| `default-model` | No | `codex` | Default AI model (`claude`, `codex`, or `gemini`) |
+| `default-agent` | No | `codex` | Default agent (`claude`, `codex`, or `gemini`) |
+| `default-model` | No | `codex` | Backward-compatible alias for `default-agent` |
 | `manage-labels` | No | `false` | Auto-create and apply labels on agent runs |
-| `dry-run` | No | `false` | Run the agent but skip commit/PR creation |
-| `preflight-only` | No | `false` | Validate setup and exit without creating/resuming an agent runner |
+| `dry-run` | No | `false` | Start an agent run but skip commit/PR creation |
+| `preflight-only` | No | `false` | Validate setup and exit without creating/resuming an agent run |
 | `timeout-minutes` | No | `10` | Max minutes to wait for agent completion |
 | `netlify-cli-version` | No | `24.8.1` | Netlify CLI version to install |
 | `debug` | No | `false` | Enable debug logging of API responses |
@@ -125,8 +126,8 @@ Or comment `@netlify make it blue` on an existing PR.
 
 ## Execution modes: `dry-run` vs `preflight-only`
 
-- `dry-run: 'true'` still starts a Netlify Agent run (external Netlify calls still happen), but it skips branch commits and pull request creation.
-- `preflight-only: 'true'` validates setup and permissions, then exits before creating/resuming any agent runner.
+- `dry-run: 'true'` still starts an agent run (external Netlify calls still happen), but it skips branch commits and pull request creation.
+- `preflight-only: 'true'` validates setup and permissions, then exits before creating/resuming any agent run.
 - If both are set to `true`, `preflight-only` behavior wins and no agent is started.
 
 ```yaml
@@ -152,7 +153,8 @@ If `preflight-only` fails, inspect `preflight-summary` and `preflight-json` outp
 
 - `netlify-auth-token` is present and valid
 - `netlify-site-id` matches a site your token can access
-- `default-model` is one of `claude`, `codex`, or `gemini`
+- `default-agent` selects one of the supported agents: `claude`, `codex`, or `gemini`
+- `default-model` remains supported as a backward-compatible alias
 - `timeout-minutes` is a positive integer
 - workflow permissions include `contents: write`, `pull-requests: write`, and `issues: write`
 
@@ -162,12 +164,13 @@ Use these outputs in subsequent workflow steps for custom automation:
 
 | Output | Description |
 |---|---|
-| `agent-id` | Netlify agent runner ID |
+| `agent-id` | Agent run ID |
 | `outcome` | `success`, `failure`, or `timeout` |
 | `agent-result` | Agent result summary text |
 | `agent-pr-url` | Pull request URL (if created) |
 | `agent-deploy-url` | Deploy preview URL |
-| `model` | AI model that was used |
+| `agent` | Agent that was used |
+| `model` | Backward-compatible alias for `agent` |
 | `trigger-text` | Cleaned trigger text / prompt |
 | `is-pr` | Whether triggered from a PR (`true`/`false`) |
 | `issue-number` | Issue or PR number |
@@ -218,6 +221,18 @@ Notes:
 - Each report includes the scenario name, run/skip decision, context, recovered state, and rendered comments.
 - Reconciliation warnings are included in simulator output under `Warnings`.
 
+## Maintainer local CI with act
+
+Use [`act`](https://github.com/nektos/act) to run the GitHub Actions CI workflow locally before pushing.
+
+```bash
+bun run act:list
+bun run act:ci
+bun run act:ci:pr
+```
+
+The repo includes `.actrc` plus push and pull request payloads under `.act/`. Normal `act` runs require Docker. On macOS, start Docker Desktop first. If Docker is unavailable, `bun run act:ci:host` runs the same job on the host machine as a faster smoke check, but it is less representative than the container-backed runner.
+
 ## What gets posted
 
 - **Status comment** — current run result with screenshot, deploy preview, and links
@@ -230,7 +245,7 @@ After the first run creates a PR, add follow-up `@netlify` comments on the PR. T
 
 ## Security
 
-- Only repository collaborators, members, and owners can trigger the agent
+- Only repository collaborators, members, and owners can trigger agent runs
 - Bot accounts (`github-actions[bot]`, `netlify-coding[bot]`) are excluded
 - Concurrency control ensures one run per issue/PR at a time
 - The `allowed-users` input can further restrict access to specific users

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: 'Netlify Agents'
-description: 'Run Netlify Agents from GitHub Issues and Pull Requests via @netlify mentions'
+name: 'Netlify Agent Runners'
+description: 'Start Netlify Agent Runners agent runs from GitHub Issues and Pull Requests via @netlify mentions'
 branding:
   icon: 'zap'
   color: 'green'
@@ -19,11 +19,15 @@ inputs:
     required: false
     default: ${{ github.token }}
   allowed-users:
-    description: 'Comma-separated list of GitHub usernames allowed to trigger the agent (optional — defaults to repo collaborators)'
+    description: 'Comma-separated list of GitHub usernames allowed to trigger agent runs (optional — defaults to repo collaborators)'
     required: false
     default: ''
+  default-agent:
+    description: 'Default agent to use (claude, codex, or gemini)'
+    required: false
+    default: 'codex'
   default-model:
-    description: 'Default AI model to use (claude, codex, or gemini)'
+    description: 'Backward-compatible alias for default-agent'
     required: false
     default: 'codex'
   manage-labels:
@@ -39,7 +43,7 @@ inputs:
     required: false
     default: '24.8.1'
   dry-run:
-    description: 'Preview mode — run the agent but skip PR creation and commits'
+    description: 'Preview mode — start an agent run but skip PR creation and commits'
     required: false
     default: 'false'
   preflight-only:
@@ -60,7 +64,7 @@ inputs:
 # ---------------------------------------------------------------------------
 outputs:
   agent-id:
-    description: 'The Netlify agent runner ID'
+    description: 'The agent run ID'
     value: ${{ steps.netlify-agent.outputs.agent-id }}
   outcome:
     description: 'Agent outcome: success, failure, or timeout'
@@ -74,8 +78,11 @@ outputs:
   agent-deploy-url:
     description: 'Deploy preview URL'
     value: ${{ steps.netlify-agent.outputs.agent-deploy-url }}
+  agent:
+    description: 'The selected agent'
+    value: ${{ steps.context-info.outputs.agent }}
   model:
-    description: 'The AI model that was used'
+    description: 'Backward-compatible alias for agent'
     value: ${{ steps.context-info.outputs.model }}
   trigger-text:
     description: 'The cleaned trigger text / prompt'
@@ -189,7 +196,8 @@ runs:
       uses: actions/github-script@v8
       env:
         ACTION_DIR: ${{ github.action_path }}
-        DEFAULT_MODEL: ${{ inputs.default-model }}
+        DEFAULT_AGENT: ${{ inputs.default-agent || inputs.default-model }}
+        DEFAULT_MODEL: ${{ inputs.default-model || inputs.default-agent }}
         DRY_RUN: ${{ inputs.dry-run }}
       with:
         github-token: ${{ inputs.github-token }}
@@ -209,7 +217,8 @@ runs:
         NETLIFY_AUTH_TOKEN: ${{ inputs.netlify-auth-token }}
         NETLIFY_SITE_ID: ${{ inputs.netlify-site-id }}
         GITHUB_TOKEN_INPUT: ${{ inputs.github-token }}
-        DEFAULT_MODEL: ${{ inputs.default-model }}
+        DEFAULT_AGENT: ${{ inputs.default-agent || inputs.default-model }}
+        DEFAULT_MODEL: ${{ inputs.default-model || inputs.default-agent }}
         TIMEOUT_MINUTES: ${{ inputs.timeout-minutes }}
         TRIGGER_TEXT: ${{ steps.context-info.outputs.trigger-text }}
         ISSUE_NUMBER: ${{ steps.context-info.outputs.issue-number }}
@@ -229,6 +238,7 @@ runs:
               netlifyAuthToken: process.env.NETLIFY_AUTH_TOKEN,
               netlifySiteId: process.env.NETLIFY_SITE_ID,
               githubToken: process.env.GITHUB_TOKEN_INPUT,
+              defaultAgent: process.env.DEFAULT_AGENT,
               defaultModel: process.env.DEFAULT_MODEL,
               timeoutMinutes: process.env.TIMEOUT_MINUTES,
               triggerText: process.env.TRIGGER_TEXT,
@@ -349,7 +359,7 @@ runs:
         issue-number: ${{ steps.context-info.outputs.issue-number }}
         body-includes: '<!-- netlify-agent-run-history -->'
 
-    - name: Extract existing agent runner ID
+    - name: Extract existing agent run ID
       id: extract-agent-id
       if: steps.trigger-check.outputs.should-run == 'true' && github.event_name != 'workflow_dispatch'
       uses: actions/github-script@v8
@@ -406,8 +416,8 @@ runs:
           const failureDetails = Array.isArray(result.failureDetails) ? result.failureDetails : [];
 
           let body = preflightOk
-            ? '### Netlify Agent Runner preflight passed ✅\n\n'
-            : '### ❌ Netlify Agent Runner preflight failed\n\n';
+            ? '### Netlify Agent Runners preflight passed ✅\n\n'
+            : '### ❌ Netlify Agent Runners preflight failed\n\n';
 
           if (preflightOk && preflightOnly) {
             body += 'Configuration is valid, and `preflight-only=true` prevented agent creation for this run.\n\n';
@@ -500,7 +510,7 @@ runs:
         token: ${{ inputs.github-token }}
         issue-number: ${{ steps.context-info.outputs.issue-number }}
         body: |
-          > This issue already has a linked pull request. Please add follow-up `@netlify` prompts on PR #${{ steps.extract-agent-id.outputs.linked-pr-number || steps.context-info.outputs.linked-pr-number }}${{ steps.extract-agent-id.outputs.agent-run-url && format(', or use the [Netlify Agents dashboard]({0})', steps.extract-agent-id.outputs.agent-run-url) || '' }}.
+          > This issue already has a linked pull request. Please add follow-up `@netlify` prompts on PR #${{ steps.extract-agent-id.outputs.linked-pr-number || steps.context-info.outputs.linked-pr-number }}${{ steps.extract-agent-id.outputs.agent-run-url && format(', or use the [Netlify Agent Runners dashboard]({0})', steps.extract-agent-id.outputs.agent-run-url) || '' }}.
 
     # -----------------------------------------------------------------------
     # 9. Create initial status comment
@@ -520,7 +530,7 @@ runs:
         script: |
           const utils = require(`${process.env.ACTION_DIR}/src/utils.js`);
           const triggerText = ${{ toJSON(steps.context-info.outputs.trigger-text) }} || '';
-          const model = ${{ toJSON(steps.context-info.outputs.model) }} || 'codex';
+          const model = ${{ toJSON(steps.context-info.outputs.agent || steps.context-info.outputs.model) }} || 'codex';
           const isDryRun = '${{ steps.context-info.outputs.is-dry-run }}' === 'true';
           const dryRunTag = isDryRun ? ' (preview)' : '';
           const ghActionUrl = `https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}`;
@@ -671,7 +681,7 @@ runs:
         github-token: ${{ inputs.github-token }}
         script: |
           const utils = require(`${process.env.ACTION_DIR}/src/utils.js`);
-          const model = ${{ toJSON(steps.context-info.outputs.model) }} || 'codex';
+          const model = ${{ toJSON(steps.context-info.outputs.agent || steps.context-info.outputs.model) }} || 'codex';
           const runnerId = ${{ toJSON(steps.extract-agent-id.outputs.agent-runner-id) }};
           const commentId = ${{ toJSON(steps.find_comment.outputs.comment-id) }} || ${{ toJSON(steps.create_comment.outputs.comment-id) }};
           const siteName = ${{ toJSON(steps.resolve-site-name.outputs.site-name) }} || 'unknown';
@@ -687,10 +697,10 @@ runs:
           });
 
     # -----------------------------------------------------------------------
-    # 13. Run the Netlify Agent (create runner, poll for completion)
+    # 13. Run Netlify Agent Runners (create an agent run, poll for completion)
     #     Dry-run mode skips PR creation and commits.
     # -----------------------------------------------------------------------
-    - name: Run Netlify Agent
+    - name: Run Netlify Agent Runners
       id: netlify-agent
       if: steps.trigger-check.outputs.should-run == 'true' && steps.should-continue.outputs.should-continue == 'true'
       shell: bash
@@ -699,7 +709,8 @@ runs:
         NETLIFY_SITE_ID: ${{ inputs.netlify-site-id }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
         TRIGGER_TEXT: ${{ steps.context-info.outputs.trigger-text }}
-        AGENT_MODEL: ${{ steps.context-info.outputs.model }}
+        NETLIFY_AGENT: ${{ steps.context-info.outputs.agent || steps.context-info.outputs.model }}
+        AGENT_MODEL: ${{ steps.context-info.outputs.model || steps.context-info.outputs.agent }}
         EXISTING_RUNNER_ID: ${{ steps.extract-agent-id.outputs.agent-runner-id }}
         HEAD_BRANCH: ${{ steps.context-info.outputs.head-ref }}
         REPOSITORY_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
@@ -749,18 +760,19 @@ runs:
         echo "failure-category=" >> $GITHUB_OUTPUT
         echo "agent-error=" >> $GITHUB_OUTPUT
 
-        echo "🚀 Starting Netlify Agent..."
-        echo "Model: $AGENT_MODEL | Site: ${SITE_NAME:-unknown} | Dry-run: ${IS_DRY_RUN:-false}"
+        echo "🚀 Starting Netlify Agent Runners..."
+        SELECTED_AGENT="${NETLIFY_AGENT:-${AGENT_MODEL:-codex}}"
+        echo "Agent: $SELECTED_AGENT | Site: ${SITE_NAME:-unknown} | Dry-run: ${IS_DRY_RUN:-false}"
 
         # Build agent args
-        AGENT_ARGS=(--json --agent "$AGENT_MODEL")
+        AGENT_ARGS=(--json --agent "$SELECTED_AGENT")
         if [ -n "${HEAD_BRANCH:-}" ]; then
           AGENT_ARGS+=(--branch "$HEAD_BRANCH")
         elif [ -n "${REPOSITORY_DEFAULT_BRANCH:-}" ]; then
           AGENT_ARGS+=(--branch "$REPOSITORY_DEFAULT_BRANCH")
         fi
 
-        # Create or reuse agent runner
+        # Create or reuse agent run
         if [ -n "${EXISTING_RUNNER_ID:-}" ]; then
           echo "🔄 Follow-up session on runner: $EXISTING_RUNNER_ID"
           SAFE_PROMPT=$(echo "$TRIGGER_TEXT" | jq -Rs .)
@@ -768,7 +780,7 @@ runs:
           for ATTEMPT in 1 2 3; do
             echo "  Attempt $ATTEMPT/3..."
             SESSION_RESULT=$(netlify api createAgentRunnerSession \
-              --data "{\"agent_runner_id\": \"$EXISTING_RUNNER_ID\", \"body\": {\"prompt\": $SAFE_PROMPT, \"agent\": \"$AGENT_MODEL\"}}" 2>/dev/null || true)
+              --data "{\"agent_runner_id\": \"$EXISTING_RUNNER_ID\", \"body\": {\"prompt\": $SAFE_PROMPT, \"agent\": \"$SELECTED_AGENT\"}}" 2>/dev/null || true)
             debug_log "createAgentRunnerSession (attempt $ATTEMPT)" "$SESSION_RESULT"
             SESSION_STATE=$(echo "$SESSION_RESULT" | jq -r '.state // empty')
             if [ "$SESSION_STATE" = "running" ]; then
@@ -788,7 +800,7 @@ runs:
             exit 1
           fi
         else
-          echo "📡 Creating new agent runner..."
+          echo "📡 Creating new agent run..."
           AGENT_STDERR=$(mktemp)
           AGENT_OUTPUT=$(netlify agents:create "$TRIGGER_TEXT" "${AGENT_ARGS[@]}" 2>"$AGENT_STDERR" || true)
           debug_log "agents:create" "$AGENT_OUTPUT"
@@ -1033,7 +1045,7 @@ runs:
           const triggerText = (process.env.TRIGGER_TEXT || '').toLowerCase();
           const owner = context.repo.owner;
           const repo = context.repo.repo;
-          const label = { name: 'netlify-agent', color: '00AD9F', description: 'Items created or modified by Netlify Agent' };
+          const label = { name: 'netlify-agent', color: '00AD9F', description: 'Items created or modified by Netlify Agent Runners' };
           try { await github.rest.issues.createLabel({ owner, repo, ...label }); } catch (e) { /* exists */ }
           const autoLabels = ['netlify-agent'];
           if (triggerText.includes('security')) autoLabels.push('security-fix');
@@ -1192,7 +1204,7 @@ runs:
         issue-number: ${{ steps.context-info.outputs.issue-number }}
         comment-id: ${{ steps.find_comment.outputs.comment-id || steps.create_comment.outputs.comment-id }}
         body: |
-          Netlify Agent run completed (status reporting encountered an error).
+          Agent run completed (status reporting encountered an error).
           [GitHub Action logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
           <!-- netlify-agent-run-status -->
         edit-mode: replace
@@ -1250,7 +1262,8 @@ runs:
         IS_PR: ${{ steps.context-info.outputs.is-pr }}
         ISSUE_NUM: ${{ steps.context-info.outputs.issue-number }}
         CONTEXT_LABEL: "${{ steps.context-info.outputs.is-pr == 'true' && format('PR #{0}', steps.context-info.outputs.issue-number) || format('Issue #{0}', steps.context-info.outputs.issue-number) }}"
-        MODEL: ${{ steps.context-info.outputs.model }}
+        AGENT: ${{ steps.context-info.outputs.agent || steps.context-info.outputs.model }}
+        MODEL: ${{ steps.context-info.outputs.model || steps.context-info.outputs.agent }}
         IS_DRY_RUN: ${{ steps.context-info.outputs.is-dry-run }}
         AGENT_ID: ${{ steps.netlify-agent.outputs.agent-id }}
         SITE_NAME: ${{ steps.resolve-site-name.outputs.site-name }}
@@ -1311,6 +1324,7 @@ runs:
             outcome,
             eventName: process.env.EVENT_NAME,
             contextLabel: process.env.CONTEXT_LABEL,
+            agent: process.env.AGENT,
             model: process.env.MODEL,
             isDryRun: process.env.IS_DRY_RUN,
             isPreflightOnly: process.env.PREFLIGHT_ONLY,
@@ -1339,14 +1353,15 @@ runs:
         SHOULD_CONTINUE: ${{ steps.should-continue.outputs.should-continue || steps.preflight.outputs.should-continue }}
         IS_PR: ${{ steps.context-info.outputs.is-pr }}
         ISSUE_NUM: ${{ steps.context-info.outputs.issue-number }}
-        MODEL: ${{ steps.context-info.outputs.model }}
+        AGENT: ${{ steps.context-info.outputs.agent || steps.context-info.outputs.model }}
+        MODEL: ${{ steps.context-info.outputs.model || steps.context-info.outputs.agent }}
         FRAMEWORK: ${{ steps.project-info.outputs.framework }}
         IS_DRY_RUN: ${{ steps.context-info.outputs.is-dry-run }}
       run: |
         echo "📊 ===== Execution Summary ====="
         echo "Status: ${OUTCOME:-skipped}"
         echo "Context: $([ "$IS_PR" = 'true' ] && echo 'PR' || echo 'Issue') #${ISSUE_NUM}"
-        echo "Model: $MODEL"
+        echo "Agent: ${AGENT:-$MODEL}"
         echo "Project: ${FRAMEWORK:-Unknown}"
         echo "Dry-run: ${IS_DRY_RUN:-false}"
         echo "Preflight-only input: ${PREFLIGHT_ONLY:-false}"

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Netlify Agent Runner - GitHub Action</title>
+  <title>Netlify Agent Runners - GitHub Action</title>
   <style>
     :root {
       --teal: #00AD9F;
@@ -145,8 +145,8 @@
 <body>
 
 <div class="hero">
-  <h1>Netlify <span>Agent Runner</span></h1>
-  <p>Trigger Netlify Agents from GitHub issues and pull requests. Just mention <code>@netlify</code> and the agent builds your site.</p>
+  <h1>Netlify <span>Agent Runners</span></h1>
+  <p>Start Netlify Agent Runners agent runs from GitHub issues and pull requests. Just mention <code>@netlify</code> and the selected agent builds your site.</p>
   <div class="hero-code">
     <span class="key">- uses:</span> <span class="val">netlify-labs/agent-runner-action@v1</span><br>
     <span class="key">&nbsp; with:</span><br>
@@ -199,13 +199,13 @@
     <span class="step-number">4</span>
     <h3>Add the workflow</h3>
     <p>Create <code>.github/workflows/netlify-agents.yml</code>:</p>
-    <pre><code>name: Netlify Agents
+    <pre><code>name: Netlify Agent Runners
 
 on:
   workflow_dispatch:
     inputs:
       trigger_text:
-        description: 'Prompt for the Netlify Agent'
+        description: 'Prompt for the agent run'
         required: true
         type: string
         default: '@netlify'
@@ -213,8 +213,8 @@ on:
         description: 'Actor triggering the agent'
         required: true
         type: string
-      model:
-        description: 'Model to use (claude, codex, gemini)'
+      agent:
+        description: 'Agent to use (claude, codex, gemini)'
         required: false
         type: string
         default: 'codex'
@@ -264,12 +264,12 @@ jobs:
   <p>Create an issue with <code>@netlify</code> in the body:</p>
   <pre><code>@netlify Build a landing page for a coffee shop with a menu and contact form</code></pre>
 
-  <h3>Choose a model</h3>
+  <h3>Choose an agent</h3>
   <p>Specify <code>claude</code>, <code>codex</code>, or <code>gemini</code> after <code>@netlify</code>:</p>
   <pre><code>@netlify claude Add a dark mode toggle
 @netlify codex Make the hero section responsive
 @netlify gemini Add a testimonials carousel</code></pre>
-  <p>Default model is <code>codex</code>. You can change the default with the <code>default-model</code> input.</p>
+  <p>Default agent is <code>codex</code>. You can change the default with the <code>default-agent</code> input.</p>
 
   <h3>Follow-up prompts</h3>
   <p>After the first run creates a PR, add follow-up <code>@netlify</code> comments on the PR to iterate. The agent continues from where it left off.</p>
@@ -277,8 +277,8 @@ jobs:
   <h3>Execution modes</h3>
   <p><code>dry-run</code> and <code>preflight-only</code> are different controls:</p>
   <ul>
-    <li><code>dry-run: 'true'</code> still starts a Netlify Agent run, but skips commit and PR creation.</li>
-    <li><code>preflight-only: 'true'</code> validates setup and exits before any agent runner is created or resumed.</li>
+    <li><code>dry-run: 'true'</code> still starts an agent run, but skips commit and PR creation.</li>
+    <li><code>preflight-only: 'true'</code> validates setup and exits before any agent run is created or resumed.</li>
     <li>If both are <code>true</code>, preflight-only behavior wins and no agent run starts.</li>
   </ul>
   <pre><code>- uses: netlify-labs/agent-runner-action@v1
@@ -305,10 +305,11 @@ jobs:
     <tr><td><code>netlify-site-id</code></td><td>Yes</td><td>&mdash;</td><td>Netlify site ID</td></tr>
     <tr><td><code>github-token</code></td><td>No</td><td><code>github.token</code></td><td>GitHub token for API calls</td></tr>
     <tr><td><code>allowed-users</code></td><td>No</td><td><code>''</code></td><td>Comma-separated usernames allowed to trigger</td></tr>
-    <tr><td><code>default-model</code></td><td>No</td><td><code>codex</code></td><td>Default AI model (<code>claude</code>, <code>codex</code>, <code>gemini</code>)</td></tr>
+    <tr><td><code>default-agent</code></td><td>No</td><td><code>codex</code></td><td>Default agent (<code>claude</code>, <code>codex</code>, <code>gemini</code>)</td></tr>
+    <tr><td><code>default-model</code></td><td>No</td><td><code>codex</code></td><td>Backward-compatible alias for <code>default-agent</code></td></tr>
     <tr><td><code>manage-labels</code></td><td>No</td><td><code>false</code></td><td>Auto-create and apply labels on runs</td></tr>
     <tr><td><code>dry-run</code></td><td>No</td><td><code>false</code></td><td>Start an agent run but skip commit/PR creation</td></tr>
-    <tr><td><code>preflight-only</code></td><td>No</td><td><code>false</code></td><td>Validate setup and exit without creating/resuming an agent runner</td></tr>
+    <tr><td><code>preflight-only</code></td><td>No</td><td><code>false</code></td><td>Validate setup and exit without creating/resuming an agent run</td></tr>
     <tr><td><code>timeout-minutes</code></td><td>No</td><td><code>10</code></td><td>Max minutes to wait for agent</td></tr>
     <tr><td><code>netlify-cli-version</code></td><td>No</td><td><code>24.8.1</code></td><td>Netlify CLI version to install</td></tr>
     <tr><td><code>debug</code></td><td>No</td><td><code>false</code></td><td>Enable debug API logging</td></tr>
@@ -321,12 +322,13 @@ jobs:
   <p>Use these in subsequent workflow steps for custom automation:</p>
   <table>
     <tr><th>Output</th><th>Description</th></tr>
-    <tr><td><code>agent-id</code></td><td>Netlify agent runner ID</td></tr>
+    <tr><td><code>agent-id</code></td><td>Agent run ID</td></tr>
     <tr><td><code>outcome</code></td><td><code>success</code>, <code>failure</code>, or <code>timeout</code></td></tr>
     <tr><td><code>agent-result</code></td><td>Agent result summary text</td></tr>
     <tr><td><code>agent-pr-url</code></td><td>Pull request URL (if created)</td></tr>
     <tr><td><code>agent-deploy-url</code></td><td>Deploy preview URL</td></tr>
-    <tr><td><code>model</code></td><td>AI model that was used</td></tr>
+    <tr><td><code>agent</code></td><td>Agent that was used</td></tr>
+    <tr><td><code>model</code></td><td>Backward-compatible alias for <code>agent</code></td></tr>
     <tr><td><code>trigger-text</code></td><td>Cleaned trigger prompt</td></tr>
     <tr><td><code>is-pr</code></td><td><code>true</code> / <code>false</code></td></tr>
     <tr><td><code>issue-number</code></td><td>Issue or PR number</td></tr>
@@ -357,8 +359,8 @@ jobs:
   <ol>
     <li>You mention <code>@netlify</code> in an issue, PR, or comment</li>
     <li>The action reacts with eyes emoji and posts an in-progress status comment</li>
-    <li>It creates a Netlify Agent runner with your prompt</li>
-    <li>The agent builds or modifies your site</li>
+    <li>It creates an agent run with your prompt</li>
+    <li>The selected agent builds or modifies your site</li>
     <li>On completion, the status comment is updated with a result summary, screenshot, and deploy preview link</li>
     <li>If triggered from an issue, a pull request is automatically created with the changes</li>
   </ol>
@@ -381,7 +383,7 @@ jobs:
 
   <div class="trouble-item">
     <strong>Preflight-only failed checks</strong>
-    <p>Use <code>preflight-summary</code> and <code>preflight-json</code> outputs to identify failing checks. Common fixes: token/site ID mismatch, invalid default model, non-positive timeout, or missing workflow permissions.</p>
+    <p>Use <code>preflight-summary</code> and <code>preflight-json</code> outputs to identify failing checks. Common fixes: token/site ID mismatch, invalid default agent, non-positive timeout, or missing workflow permissions.</p>
   </div>
 
   <div class="trouble-item">
@@ -400,8 +402,8 @@ jobs:
   </div>
 
   <div class="trouble-item">
-    <strong>"Agent Runner [model] is not available"</strong>
-    <p>The AI provider is temporarily down. Try a different model: <code>@netlify claude</code>, <code>@netlify codex</code>, or <code>@netlify gemini</code>.</p>
+    <strong>"Requested agent is not available"</strong>
+    <p>The selected agent is temporarily unavailable. Try a different agent: <code>@netlify claude</code>, <code>@netlify codex</code>, or <code>@netlify gemini</code>.</p>
   </div>
 
   <div class="trouble-item">
@@ -418,7 +420,7 @@ jobs:
 </div>
 
 <footer>
-  <p>Netlify Agent Runner &middot; <a href="https://github.com/netlify-labs/agent-runner-action">GitHub</a> &middot; <a href="https://www.netlify.com/products/agents/">Netlify Agents</a></p>
+  <p>Netlify Agent Runners &middot; <a href="https://github.com/netlify-labs/agent-runner-action">GitHub</a> &middot; <a href="https://www.netlify.com/products/agents/">Netlify Agent Runners</a></p>
 </footer>
 
 </body>

--- a/docs/plans/agent-runner-hardening-plan.md
+++ b/docs/plans/agent-runner-hardening-plan.md
@@ -1,4 +1,4 @@
-# Netlify Agent Runner Hardening Plan
+# Netlify Agent Runners Hardening Plan
 
 Status: draft plan  
 Scope: ideas 1, 4, 5, 6, 7, 8, 9, and 11 from the idea-wizard pass  
@@ -6,7 +6,7 @@ Canonical consumer slug: `netlify-labs/agent-runner-action@v1`
 
 ## Purpose
 
-This plan describes a reliability and operator-experience hardening pass for the Netlify Agent Runner GitHub Action. The action already provides the core user workflow: a GitHub user mentions `@netlify` in an issue, pull request, review, review comment, issue comment, or manual dispatch; the action extracts context, starts or resumes a Netlify Agent run, updates status comments, and optionally creates or updates a pull request.
+This plan describes a reliability and operator-experience hardening pass for the Netlify Agent Runners GitHub Action. The action already provides the core user workflow: a GitHub user mentions `@netlify` in an issue, pull request, review, review comment, issue comment, or manual dispatch; the action extracts context, starts or resumes an agent run, updates status comments, and optionally creates or updates a pull request.
 
 The next layer of value is not another flashy feature. It is making the action easier to trust, debug, test, and support. The selected ideas all point in the same direction:
 
@@ -58,7 +58,7 @@ Important current constraints:
 - The canonical consumer slug for this plan is `netlify-labs/agent-runner-action@v1`.
 - The action currently relies on Bun, Netlify CLI, GitHub CLI, `jq`, and GitHub APIs.
 - A lot of orchestration still lives inline in `action.yml` Bash. This plan does not require a full runner rewrite, but it should extract pure parsing/rendering/decision logic into testable modules where that directly supports the selected ideas.
-- `dry-run` currently means "run the agent but skip PR creation and commits." It is not the same as "do not contact Netlify."
+- `dry-run` currently means "start an agent run but skip PR creation and commits." It is not the same as "do not contact Netlify."
 
 ## Goals
 
@@ -162,8 +162,8 @@ It should return:
 {
   category: 'agent-timeout',
   title: 'Agent timed out before completion',
-  summary: 'The Netlify Agent did not reach a terminal state before the configured timeout.',
-  remediation: ['Try a smaller prompt', 'Increase timeout-minutes', 'Check the Netlify Agents dashboard'],
+  summary: 'The agent run did not reach a terminal state before the configured timeout.',
+  remediation: ['Try a smaller prompt', 'Increase timeout-minutes', 'Check the Netlify Agent Runners dashboard'],
   severity: 'error',
   retryable: true,
   userActionRequired: false
@@ -386,7 +386,7 @@ Selected idea: 4.
 
 ### User Problem
 
-Follow-up prompts depend on recovering the previous Netlify Agent runner ID. The current implementation parses a sticky status comment first and falls back to PR body markers. That is useful but fragile. If a comment is deleted, edited, partially rendered, or contains malformed session JSON, the action can lose continuity.
+Follow-up prompts depend on recovering the previous agent run ID. The current implementation parses a sticky status comment first and falls back to PR body markers. That is useful but fragile. If a comment is deleted, edited, partially rendered, or contains malformed session JSON, the action can lose continuity.
 
 ### Plan
 
@@ -472,7 +472,7 @@ Add a new optional input:
 
 ```yaml
 preflight-only:
-  description: 'Validate setup and configuration without starting a Netlify Agent run'
+  description: 'Validate setup and configuration without starting an agent run'
   required: false
   default: 'false'
 ```
@@ -480,7 +480,7 @@ preflight-only:
 This is intentionally separate from `dry-run`.
 
 - `dry-run=true`: starts the agent but skips PR creation and commits.
-- `preflight-only=true`: validates setup and exits before creating or resuming an agent runner.
+- `preflight-only=true`: validates setup and exits before creating or resuming an agent run.
 
 This separation avoids surprising existing users.
 
@@ -490,7 +490,7 @@ Static checks:
 
 - `netlify-auth-token` input is present.
 - `netlify-site-id` input is present.
-- `default-model` is one of `claude`, `codex`, or `gemini`.
+- `default-agent` is one of `claude`, `codex`, or `gemini`; `default-model` remains a compatibility alias.
 - `timeout-minutes` is a positive integer.
 - `github-token` input is present.
 - Trigger context can be extracted.
@@ -527,7 +527,7 @@ Composite actions do not have a native "return early" primitive. The implementat
 For preflight-only success:
 
 ```markdown
-### Netlify Agent Runner preflight passed
+### Netlify Agent Runners preflight passed
 
 The action configuration looks valid. No agent was started because `preflight-only` is enabled.
 
@@ -544,7 +544,7 @@ Checks:
 For preflight failure:
 
 ```markdown
-### Netlify Agent Runner preflight failed
+### Netlify Agent Runners preflight failed
 
 The action did not start an agent run because setup validation failed.
 
@@ -576,7 +576,7 @@ Required cases:
 
 ### Success Criteria
 
-- Users can validate setup without starting a Netlify Agent.
+- Users can validate setup without starting an agent run.
 - Setup failures produce specific, actionable comments and summaries.
 - Existing default runs continue unless preflight fails.
 - `dry-run` semantics remain unchanged.
@@ -629,7 +629,7 @@ Prompt:
   fix the mobile layout
 
 Would update status comment with:
-  Netlify Agent Runner...
+  Netlify Agent Runners...
 ```
 
 JSON output:
@@ -709,7 +709,7 @@ Parse `action.yml` and validate:
 - Every declared output appears in the README output table, or is explicitly marked internal/undocumented.
 - Workflow examples use only declared inputs.
 - Required secrets are described consistently.
-- Default model is documented consistently.
+- Default agent is documented consistently.
 - `dry-run`, `netlify-cli-version`, `timezone`, and the proposed `preflight-only` input are documented.
 - The docs site includes the canonical slug.
 - Workflow templates include required permissions: `contents: write`, `pull-requests: write`, `issues: write`.
@@ -816,8 +816,8 @@ The classifier should accept:
 
 `model-unavailable`
 
-- Trigger: error text like "Agent Runner X is not available."
-- User message: retry with another model, e.g. `@netlify codex`, `@netlify claude`, or `@netlify gemini`.
+- Trigger: error text like "Agent X is not available."
+- User message: retry with another agent, e.g. `@netlify codex`, `@netlify claude`, or `@netlify gemini`.
 - Retryable: true.
 
 `agent-create-failed`
@@ -941,14 +941,14 @@ Generate a `$GITHUB_STEP_SUMMARY` Markdown report for every triggered run. It sh
 Run overview:
 
 ```markdown
-## Netlify Agent Runner
+## Netlify Agent Runners
 
 | Field | Value |
 |---|---|
 | Outcome | success |
 | Event | issue_comment |
 | Context | PR #42 |
-| Model | codex |
+| Agent | codex |
 | Dry-run | false |
 | Preflight-only | false |
 ```
@@ -984,10 +984,10 @@ Failure:
 **Retryable:** yes  
 **User action required:** no
 
-The Netlify Agent did not finish before the configured timeout.
+The agent run did not finish before the configured timeout.
 
 Suggested next steps:
-- Check the Netlify Agents dashboard.
+- Check the Netlify Agent Runners dashboard.
 - Increase `timeout-minutes`.
 - Split the task into a smaller prompt.
 ```
@@ -1065,7 +1065,7 @@ Scope:
 - Refactor `src/extract-agent-id.js` to use it.
 - Add unit tests.
 
-Why it is self-contained: it hardens follow-up state without changing the agent runner flow.
+Why it is self-contained: it hardens follow-up state without changing the agent run flow.
 
 ### Slice 3: Failure Taxonomy And Error Comments
 

--- a/docs/plans/example-repo-verification-checklist.md
+++ b/docs/plans/example-repo-verification-checklist.md
@@ -34,7 +34,7 @@ from that branch) before any `@main` or release-tag movement.
 | S1 | Preflight-only success | `workflow_dispatch` with `preflight-only=true` after the input is implemented. | Step summary shows validation success and no agent start. Because this is `workflow_dispatch`, no status comment is expected. |
 | S2 | Invalid site ID failure | `workflow_dispatch` with `site_id_override=invalid-site-id`. | Fails fast with clear error text. Step summary includes readable failure details and logs link. Because this is `workflow_dispatch`, no issue/PR comment is expected. |
 | S3 | Dry-run prompt | `workflow_dispatch` with `dry_run=true` and a normal prompt. | Agent run starts, but no commit/PR is created. Summary states dry-run path. Status comment still shows run context and outcome. |
-| S4 | Normal issue trigger | Open an issue with `@netlify` prompt text. | Eyes reaction appears. Status comment updates from in-progress to final outcome with model/result and links (deploy/PR when available). |
+| S4 | Normal issue trigger | Open an issue with `@netlify` prompt text. | Eyes reaction appears. Status comment updates from in-progress to final outcome with agent/result and links (deploy/PR when available). |
 | S5 | PR follow-up trigger | Comment `@netlify ...` on the active PR created by the action. | Existing PR receives follow-up status/history updates. Run keeps continuity on the same PR thread. |
 | S6 | Failure path with readable summary/comment output | Trigger one deterministic failure mode (for example, invalid site ID or expired token). | Summary and comment clearly state what failed, where it failed, and what to do next; include run logs link and Netlify dashboard link when available. |
 

--- a/docs/plans/example-repo-verification-workflow.yml
+++ b/docs/plans/example-repo-verification-workflow.yml
@@ -4,13 +4,13 @@
 # Verification policy:
 # - Test netlify-labs/agent-runner-action from dw/actions-updates (or a SHA from that branch).
 # - Do not repoint @main or release tags during verification.
-name: Netlify Agents Branch Verification
+name: Netlify Agent Runners Branch Verification
 
 on:
   workflow_dispatch:
     inputs:
       trigger_text:
-        description: 'Prompt for the Netlify Agent'
+        description: 'Prompt for the agent run'
         required: true
         type: string
         default: '@netlify codex Add a tiny visual polish to the hero section'
@@ -18,8 +18,8 @@ on:
         description: 'GitHub username to attribute this run to'
         required: true
         type: string
-      model:
-        description: 'AI model to use'
+      agent:
+        description: 'Agent to use'
         required: false
         type: choice
         options:
@@ -28,7 +28,7 @@ on:
           - gemini
         default: codex
       dry_run:
-        description: 'Run the agent but skip commits/PR creation'
+        description: 'Start an agent run but skip commits/PR creation'
         required: false
         type: boolean
         default: false
@@ -92,7 +92,7 @@ jobs:
         shell: bash
         run: |
           {
-            echo "### Agent Runner Branch Verification"
+            echo "### Agent Runners Branch Verification"
             echo "- Action under test: \`${ACTION_UNDER_TEST_REPO}@${ACTION_UNDER_TEST_REF}\`"
             echo "- Resolved action commit SHA: \`${{ steps.action-sha.outputs.sha }}\`"
             echo "- Example repo run id: \`${GITHUB_RUN_ID}\`"
@@ -116,17 +116,17 @@ jobs:
 
       # If you pin to an immutable SHA, update both ACTION_UNDER_TEST_REF and
       # the @ref on these two uses lines together.
-      - name: Run Agent Runner (workflow_dispatch)
+      - name: Run Agent Runners (workflow_dispatch)
         if: github.event_name == 'workflow_dispatch'
         uses: netlify-labs/agent-runner-action@dw/actions-updates
         with:
           netlify-auth-token: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           netlify-site-id: ${{ steps.dispatch-site.outputs.value }}
-          default-model: ${{ inputs.model }}
+          default-agent: ${{ inputs.agent }}
           dry-run: ${{ inputs.dry_run }}
           # preflight-only: 'true' # Enable when preflight-only is implemented.
 
-      - name: Run Agent Runner (issue and PR events)
+      - name: Run Agent Runners (issue and PR events)
         if: github.event_name != 'workflow_dispatch'
         uses: netlify-labs/agent-runner-action@dw/actions-updates
         with:

--- a/docs/plans/preflight-only-contract.md
+++ b/docs/plans/preflight-only-contract.md
@@ -19,7 +19,7 @@ The contract applies to action behavior when a new optional input
 2. `dry-run` semantics do not change.
    - `dry-run=true` still starts the agent.
    - `dry-run=true` still skips commit/PR creation.
-3. `preflight-only=true` does not start or resume an agent runner.
+3. `preflight-only=true` does not start or resume an agent run.
    - It only validates configuration and exits after reporting.
 4. If both `dry-run=true` and `preflight-only=true`, preflight-only wins.
    - No agent is started.

--- a/example-workflow.yml
+++ b/example-workflow.yml
@@ -5,12 +5,12 @@
 #   1. Install the netlify-coding GitHub App on your repo
 #   2. Add NETLIFY_AUTH_TOKEN and NETLIFY_SITE_ID as repository secrets
 #
-# Usage: mention @netlify in an issue, PR, or comment to trigger the agent.
+# Usage: mention @netlify in an issue, PR, or comment to trigger an agent run.
 #   @netlify Build a landing page with a hero section
 #   @netlify claude Add dark mode support
 #   @netlify codex Fix the mobile layout
 
-name: Netlify Agents
+name: Netlify Agent Runners
 
 on:
   workflow_dispatch:
@@ -24,8 +24,8 @@ on:
         description: 'GitHub username to attribute this run to'
         required: true
         type: string
-      model:
-        description: 'AI model to use'
+      agent:
+        description: 'Agent to use'
         required: false
         type: choice
         options:
@@ -70,10 +70,10 @@ jobs:
           netlify-auth-token: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           netlify-site-id: ${{ secrets.NETLIFY_SITE_ID }}
           # Optional settings:
-          # default-model: 'codex'        # Default AI model (claude, codex, gemini)
+          # default-agent: 'codex'        # Default agent (claude, codex, gemini)
           # manage-labels: 'false'        # Auto-create and apply labels
-          # dry-run: 'false'              # Still runs Netlify Agent; skips commit/PR creation
-          # preflight-only: 'false'       # Validate setup only; starts no agent runner
+          # dry-run: 'false'              # Still starts an agent run; skips commit/PR creation
+          # preflight-only: 'false'       # Validate setup only; starts no agent run
           # If both are true, preflight-only behavior wins.
           # preflight-only: 'true'        # Example: verify config/permissions and exit
           # dry-run: 'true'               # Example: run preview without committing changes

--- a/fixtures/events/workflow-dispatch.json
+++ b/fixtures/events/workflow-dispatch.json
@@ -1,7 +1,7 @@
 {
   "inputs": {
     "trigger_text": "@netlify gemini run preflight checks",
-    "model": "gemini",
+    "agent": "gemini",
     "actor": "repo-admin"
   },
   "sender": { "login": "repo-admin" },

--- a/fixtures/github/existing-status-comment-malformed-session-data.json
+++ b/fixtures/github/existing-status-comment-malformed-session-data.json
@@ -1,6 +1,6 @@
 {
   "data": {
     "id": 7002,
-    "body": "### Netlify Agent Runner\n\n[Netlify agent run](https://app.netlify.com/projects/agent-runner-action-example/agent-runs/runner-xyz999)\n<!-- netlify-agent-session-data:{not-json} -->\n<!-- netlify-agent-runner-id:runner-xyz999 -->\n<!-- netlify-agent-run-status -->"
+    "body": "### Netlify Agent Runners\n\n[Agent run](https://app.netlify.com/projects/agent-runner-action-example/agent-runs/runner-xyz999)\n<!-- netlify-agent-session-data:{not-json} -->\n<!-- netlify-agent-runner-id:runner-xyz999 -->\n<!-- netlify-agent-run-status -->"
   }
 }

--- a/fixtures/github/existing-status-comment-with-runner.json
+++ b/fixtures/github/existing-status-comment-with-runner.json
@@ -1,6 +1,6 @@
 {
   "data": {
     "id": 7001,
-    "body": "### [Netlify Agent Runner in progress](https://app.netlify.com/projects/agent-runner-action-example/agent-runs/runner-abc123)\n\n[GitHub Action logs](https://github.com/netlify-labs/agent-runner-action-example/actions/runs/999)\n<!-- netlify-agent-session-data:{\"session_1\":{\"gh_action_url\":\"https://github.com/netlify-labs/agent-runner-action-example/actions/runs/999\"}} -->\n<!-- netlify-agent-runner-id:runner-abc123 -->\n<!-- netlify-agent-run-status -->"
+    "body": "### [Netlify Agent Runners in progress](https://app.netlify.com/projects/agent-runner-action-example/agent-runs/runner-abc123)\n\n[GitHub Action logs](https://github.com/netlify-labs/agent-runner-action-example/actions/runs/999)\n<!-- netlify-agent-session-data:{\"session_1\":{\"gh_action_url\":\"https://github.com/netlify-labs/agent-runner-action-example/actions/runs/999\"}} -->\n<!-- netlify-agent-runner-id:runner-abc123 -->\n<!-- netlify-agent-run-status -->"
   }
 }

--- a/src/action-wiring.test.js
+++ b/src/action-wiring.test.js
@@ -217,6 +217,7 @@ describe('action.yml wiring', () => {
       'netlify-auth-token',
       'netlify-site-id',
       'github-token',
+      'default-agent',
       'default-model',
       'timeout-minutes',
       'debug',
@@ -233,6 +234,7 @@ describe('action.yml wiring', () => {
     const expected = [
       'agent-id',
       'outcome',
+      'agent',
       'model',
       'trigger-text',
       'is-pr',

--- a/src/check-docs-drift.js
+++ b/src/check-docs-drift.js
@@ -18,7 +18,7 @@ const WORKFLOW_FILES = [
   'workflow-templates/netlify-agents.yml',
 ];
 const IMPORTANT_DEFAULT_INPUTS = [
-  'default-model',
+  'default-agent',
   'dry-run',
   'timeout-minutes',
   'timezone',

--- a/src/check-docs-drift.test.js
+++ b/src/check-docs-drift.test.js
@@ -51,7 +51,7 @@ describe('check-docs-drift', () => {
   it('detects missing input documentation rows', () => {
     const readme = read('README.md');
     const driftedReadme = readme.replace(
-      "| `dry-run` | No | `false` | Run the agent but skip commit/PR creation |\n",
+      "| `dry-run` | No | `false` | Start an agent run but skip commit/PR creation |\n",
       ''
     );
     const errors = checkDocsDrift({

--- a/src/comment-markers.test.js
+++ b/src/comment-markers.test.js
@@ -34,7 +34,7 @@ describe('render helpers', () => {
 describe('parseRunnerId', () => {
   it('extracts runner ids from markdown with surrounding text', () => {
     const body = [
-      '### Netlify Agent Runner completed',
+      '### Netlify Agent Runners run completed',
       '',
       '<!-- netlify-agent-runner-id:abc_123-def -->',
       '<!-- netlify-agent-run-status -->',

--- a/src/contracts.js
+++ b/src/contracts.js
@@ -8,7 +8,7 @@
 /** @typedef {'info' | 'warning' | 'error'} FailureSeverity */
 /** @typedef {'validate-env' | 'resolve-site' | 'create-agent' | 'create-session' | 'poll-agent' | 'commit' | 'create-pr' | 'comment-update' | 'unknown'} FailureStage */
 
-/** @typedef {'missing-auth-token' | 'missing-site-id' | 'site-lookup-failed' | 'netlify-cli-missing' | 'netlify-cli-install-failed' | 'model-unavailable' | 'agent-create-failed' | 'session-create-failed' | 'agent-timeout' | 'agent-failed' | 'deploy-preview-unavailable' | 'commit-to-branch-failed' | 'pull-request-create-failed' | 'github-permission-denied' | 'github-api-failed' | 'malformed-api-response' | 'unknown'} FailureCategory */
+/** @typedef {'missing-auth-token' | 'missing-site-id' | 'site-lookup-failed' | 'netlify-cli-missing' | 'netlify-cli-install-failed' | 'agent-unavailable' | 'model-unavailable' | 'agent-create-failed' | 'session-create-failed' | 'agent-timeout' | 'agent-failed' | 'deploy-preview-unavailable' | 'commit-to-branch-failed' | 'pull-request-create-failed' | 'github-permission-denied' | 'github-api-failed' | 'malformed-api-response' | 'unknown'} FailureCategory */
 
 /**
  * Shared hidden markers embedded in issue/PR comments.
@@ -68,6 +68,7 @@
  * @property {'success' | 'failure' | 'timeout' | 'skipped' | 'unknown'} outcome
  * @property {string} eventName
  * @property {string} contextLabel
+ * @property {string} agent
  * @property {string} model
  * @property {boolean} isDryRun
  * @property {boolean} isPreflightOnly
@@ -109,6 +110,7 @@ const FAILURE_CATEGORIES = Object.freeze([
   'site-lookup-failed',
   'netlify-cli-missing',
   'netlify-cli-install-failed',
+  'agent-unavailable',
   'model-unavailable',
   'agent-create-failed',
   'session-create-failed',
@@ -194,7 +196,7 @@ function createReconciledState(overrides = {}) {
 function createFailureClassification(overrides = {}) {
   return {
     category: normalizeFailureCategory(overrides.category || 'unknown'),
-    title: overrides.title || 'Netlify Agent Runner failed',
+    title: overrides.title || 'Netlify Agent Runners run failed',
     summary: overrides.summary || 'The run failed before completion.',
     remediation: Array.isArray(overrides.remediation) ? overrides.remediation : [],
     severity: normalizeFailureSeverity(overrides.severity || 'error'),
@@ -244,7 +246,8 @@ function createStepSummaryInput(overrides = {}) {
       : 'unknown',
     eventName: overrides.eventName || '',
     contextLabel: overrides.contextLabel || '',
-    model: overrides.model || 'codex',
+    agent: overrides.agent || overrides.model || 'codex',
+    model: overrides.agent || overrides.model || 'codex',
     isDryRun: overrides.isDryRun === true,
     isPreflightOnly: overrides.isPreflightOnly === true,
     issueNumber: overrides.issueNumber || '',

--- a/src/contracts.test.js
+++ b/src/contracts.test.js
@@ -23,6 +23,7 @@ describe('contracts category/stage/severity lists', () => {
       'site-lookup-failed',
       'netlify-cli-missing',
       'netlify-cli-install-failed',
+      'agent-unavailable',
       'model-unavailable',
       'agent-create-failed',
       'session-create-failed',
@@ -55,7 +56,7 @@ describe('createFailureClassification', () => {
   it('returns stable defaults', () => {
     const result = contracts.createFailureClassification();
     assert.equal(result.category, 'unknown');
-    assert.equal(result.title, 'Netlify Agent Runner failed');
+    assert.equal(result.title, 'Netlify Agent Runners run failed');
     assert.equal(result.summary, 'The run failed before completion.');
     assert.deepEqual(result.remediation, []);
     assert.equal(result.severity, 'error');

--- a/src/cross-post-to-pr.js
+++ b/src/cross-post-to-pr.js
@@ -40,7 +40,7 @@ module.exports = async function crossPostToPR({ github, context }) {
   // Update issue status comment with redirect note
   const issueCommentId = process.env.STATUS_COMMENT_ID || '';
   if (issueCommentId && statusBody) {
-    const note = `> [!NOTE]\n> A Pull Request was opened for this here #${prNumber}.\n>\n> Leave follow-up \`@netlify\` prompts on PR #${prNumber}, or use the [Netlify Agents dashboard](${agentRunUrl}) to continue iterating.`;
+    const note = `> [!NOTE]\n> A Pull Request was opened for this here #${prNumber}.\n>\n> Leave follow-up \`@netlify\` prompts on PR #${prNumber}, or use the [Netlify Agent Runners dashboard](${agentRunUrl}) to continue iterating.`;
     const firstNewline = statusBody.indexOf('\n');
     const noteBody = firstNewline !== -1
       ? statusBody.slice(0, firstNewline) + '\n\n' + note + statusBody.slice(firstNewline)

--- a/src/extract-agent-id.js
+++ b/src/extract-agent-id.js
@@ -1,4 +1,4 @@
-// Extract existing agent runner ID and session data from status comment or PR body.
+// Extract existing agent run ID and session data from status comment or PR body.
 // Sets outputs: agent-runner-id, session-data-map, agent-run-url, has-linked-pr, linked-pr-number
 
 /** @typedef {import('./types').ActionParams} ActionParams */
@@ -53,7 +53,7 @@ module.exports = async function extractAgentId({ github, context, core, inputs }
 
   // Preserve current behavior: prefer explicit URL links from comment/PR body.
   const bodyForUrl = statusCommentBody || prBody;
-  const urlMatch = bodyForUrl.match(/\[(?:View agent run|Netlify agent run)\]\((https:\/\/app\.netlify\.com\/projects\/[^)]+)\)/);
+  const urlMatch = bodyForUrl.match(/\[(?:View agent run|Netlify agent run|Agent run)\]\((https:\/\/app\.netlify\.com\/projects\/[^)]+)\)/);
   core.setOutput('agent-run-url', urlMatch ? urlMatch[1] : reconciled.agentRunUrl);
 
   if (reconciled.linkedPrNumber) {

--- a/src/failure-taxonomy.js
+++ b/src/failure-taxonomy.js
@@ -1,4 +1,4 @@
-// Deterministic failure classifier for Netlify Agent Runner.
+// Deterministic failure classifier for Netlify Agent Runners.
 // Produces stable categories and user-facing metadata that can be reused
 // by comment rendering and step-summary generation.
 
@@ -119,11 +119,23 @@ const FAILURE_TAXONOMY = Object.freeze({
     userActionRequired: false,
     stage: 'validate-env',
   }),
-  'model-unavailable': freezeProfile({
-    title: 'Requested model is unavailable',
-    summary: 'Netlify reported that the selected model is not currently available.',
+  'agent-unavailable': freezeProfile({
+    title: 'Requested agent is unavailable',
+    summary: 'Netlify reported that the selected agent is not currently available.',
     remediation: [
-      'Retry with a different model (`claude`, `codex`, or `gemini`).',
+      'Retry with a different agent (`claude`, `codex`, or `gemini`).',
+      'Retry later if the provider outage is temporary.',
+    ],
+    severity: 'error',
+    retryable: true,
+    userActionRequired: false,
+    stage: 'create-agent',
+  }),
+  'model-unavailable': freezeProfile({
+    title: 'Requested agent is unavailable',
+    summary: 'Netlify reported that the selected agent is not currently available.',
+    remediation: [
+      'Retry with a different agent (`claude`, `codex`, or `gemini`).',
       'Retry later if the provider outage is temporary.',
     ],
     severity: 'error',
@@ -132,8 +144,8 @@ const FAILURE_TAXONOMY = Object.freeze({
     stage: 'create-agent',
   }),
   'agent-create-failed': freezeProfile({
-    title: 'Failed to create Netlify Agent run',
-    summary: 'The initial Netlify agent runner creation request did not succeed.',
+    title: 'Failed to create agent run',
+    summary: 'The initial agent run creation request did not succeed.',
     remediation: [
       'Check the Netlify API error details in workflow logs.',
       'Retry the run after confirming site and auth configuration.',
@@ -145,7 +157,7 @@ const FAILURE_TAXONOMY = Object.freeze({
   }),
   'session-create-failed': freezeProfile({
     title: 'Failed to create follow-up session',
-    summary: 'A follow-up prompt could not be attached to the existing Netlify agent runner.',
+    summary: 'A follow-up prompt could not be attached to the existing agent run.',
     remediation: [
       'Retry the prompt to create a new follow-up session.',
       'If repeated, start a fresh run instead of reusing the old runner ID.',
@@ -157,7 +169,7 @@ const FAILURE_TAXONOMY = Object.freeze({
   }),
   'agent-timeout': freezeProfile({
     title: 'Agent timed out before completion',
-    summary: 'The Netlify agent did not reach a terminal state within timeout-minutes.',
+    summary: 'The agent run did not reach a terminal state within timeout-minutes.',
     remediation: [
       'Try a smaller or more focused prompt.',
       'Increase `timeout-minutes` if longer runs are expected.',
@@ -169,7 +181,7 @@ const FAILURE_TAXONOMY = Object.freeze({
   }),
   'agent-failed': freezeProfile({
     title: 'Agent run failed',
-    summary: 'The Netlify agent reached a failed/error/cancelled terminal state.',
+    summary: 'The agent run reached a failed/error/cancelled terminal state.',
     remediation: [
       'Inspect the agent error details and logs for the failing operation.',
       'Retry with adjusted prompt scope after addressing root cause.',
@@ -252,7 +264,7 @@ const FAILURE_TAXONOMY = Object.freeze({
     stage: 'unknown',
   }),
   unknown: freezeProfile({
-    title: 'Netlify Agent Runner failed',
+    title: 'Netlify Agent Runners run failed',
     summary: 'The run failed before completion and did not match a known failure category.',
     remediation: [
       'Inspect workflow logs for the first concrete error.',
@@ -408,9 +420,10 @@ function detectFailureCategory(signal = {}) {
 
   if (matchesAny(text, [
     /agent runner \w+ is not available/i,
+    /agent \w+ is not available/i,
     /model .*?(unavailable|not available|unsupported)/i,
   ])) {
-    return 'model-unavailable';
+    return 'agent-unavailable';
   }
 
   if (stage === 'create-session' || matchesAny(text, [

--- a/src/failure-taxonomy.test.js
+++ b/src/failure-taxonomy.test.js
@@ -39,11 +39,11 @@ describe('detectFailureCategory', () => {
         signal: { error: 'bun install -g netlify-cli failed with exit code 1' },
       },
       {
-        category: 'model-unavailable',
+        category: 'agent-unavailable',
         signal: { error: 'Agent Runner Claude is not available right now' },
       },
       {
-        category: 'model-unavailable',
+        category: 'agent-unavailable',
         signal: { errorMessage: 'Agent Runner codex is not available for this account' },
       },
       {
@@ -116,6 +116,14 @@ describe('detectFailureCategory', () => {
     });
     assert.equal(category, 'agent-timeout');
   });
+
+  it('accepts legacy model-unavailable category overrides', () => {
+    const category = detectFailureCategory({
+      category: 'model-unavailable',
+      error: 'Agent Runner codex is not available right now',
+    });
+    assert.equal(category, 'model-unavailable');
+  });
 });
 
 describe('classifyFailure', () => {
@@ -137,9 +145,9 @@ describe('classifyFailure', () => {
         userActionRequired: true,
       },
       {
-        name: 'model unavailable',
+        name: 'agent unavailable',
         signal: { error: 'Agent Runner codex is not available right now' },
-        category: 'model-unavailable',
+        category: 'agent-unavailable',
         retryable: true,
         userActionRequired: false,
       },

--- a/src/format-comment.js
+++ b/src/format-comment.js
@@ -6,7 +6,7 @@
 //   node src/format-comment.js in-progress  → prints in-progress comment body
 //
 // Reads from environment variables:
-//   TRIGGER_TEXT, AGENT_MODEL, AGENT_LINK, ACTION_LINK, AGENT_ID, IS_DRY_RUN
+//   TRIGGER_TEXT, NETLIFY_AGENT, AGENT_MODEL, AGENT_LINK, ACTION_LINK, AGENT_ID, IS_DRY_RUN
 
 /** @typedef {import('./types').InProgressCommentOptions} InProgressCommentOptions */
 
@@ -16,7 +16,7 @@ const command = process.argv[2];
 
 if (command === 'in-progress') {
   const triggerText = process.env.TRIGGER_TEXT || '';
-  const model = process.env.AGENT_MODEL || 'codex';
+  const model = process.env.NETLIFY_AGENT || process.env.AGENT_MODEL || 'codex';
   const agentLink = process.env.AGENT_LINK || '';
   const actionLink = process.env.ACTION_LINK || '';
   const agentId = process.env.AGENT_ID || '';

--- a/src/generate-error-comment.js
+++ b/src/generate-error-comment.js
@@ -26,6 +26,7 @@ function sanitizeErrorText(value) {
   return (value || '')
     .replace(ANSI_PATTERN, '')
     .replace(/[\u0000-\u0008\u000b-\u001f\u007f]/g, '')
+    .replace(/\bAgent Runner (\w+) is not available\b/gi, 'Agent $1 is not available')
     .replace(/```/g, "'''")
     .trim();
 }
@@ -40,14 +41,14 @@ function truncateErrorText(value) {
 }
 
 /**
- * Preserve explicit model fallback guidance when providers are unavailable.
+ * Preserve explicit agent fallback guidance when providers are unavailable.
  * @param {string} category
  * @param {string} errorText
  * @returns {string}
  */
-function renderModelUnavailableHint(category, errorText) {
-  if (category !== 'model-unavailable') return '';
-  const providerMatch = errorText.match(/Agent Runner (\w+) is not available/i);
+function renderAgentUnavailableHint(category, errorText) {
+  if (category !== 'agent-unavailable' && category !== 'model-unavailable') return '';
+  const providerMatch = errorText.match(/(?:Agent Runner|agent) (\w+) is not available/i);
   if (!providerMatch) return '';
 
   const unavailableModel = providerMatch[1].toLowerCase();
@@ -84,7 +85,7 @@ module.exports = async function generateErrorComment({ core }) {
     statusCode: statusCode || undefined,
   });
   const safeError = truncateErrorText(sanitizeErrorText(agentError));
-  const modelUnavailableHint = renderModelUnavailableHint(failure.category, agentError);
+  const agentUnavailableHint = renderAgentUnavailableHint(failure.category, agentError);
 
   let message = agentRunUrl
     ? `### [❌ ${failure.title}](${agentRunUrl})\n\n`
@@ -104,8 +105,8 @@ module.exports = async function generateErrorComment({ core }) {
     message += '\n';
   }
 
-  if (modelUnavailableHint) {
-    message += `${modelUnavailableHint}\n\n`;
+  if (agentUnavailableHint) {
+    message += `${agentUnavailableHint}\n\n`;
   }
 
   if (safeError) {
@@ -114,8 +115,8 @@ module.exports = async function generateErrorComment({ core }) {
 
   /** @type {string[]} */
   const links = [];
-  if (agentRunUrl) links.push(`[Netlify agent run](${agentRunUrl})`);
-  if (!agentRunUrl && agentDashboardUrl) links.push(`[Netlify Agents dashboard](${agentDashboardUrl})`);
+  if (agentRunUrl) links.push(`[Agent run](${agentRunUrl})`);
+  if (!agentRunUrl && agentDashboardUrl) links.push(`[Netlify Agent Runners dashboard](${agentDashboardUrl})`);
   if (ghActionUrl) links.push(`[GitHub Action logs](${ghActionUrl})`);
   if (links.length > 0) {
     message += links.join(' • ') + '\n\n';

--- a/src/generate-error-comment.test.js
+++ b/src/generate-error-comment.test.js
@@ -107,9 +107,9 @@ describe('generate-error-comment', () => {
     });
 
     const body = await renderComment();
-    assert.ok(body.includes('Requested model is unavailable'));
+    assert.ok(body.includes('Requested agent is unavailable'));
     assert.ok(body.includes('`@netlify codex` or `@netlify gemini`'));
-    assert.ok(body.includes('[Netlify agent run](https://app.netlify.com/projects/example-site/agent-runs/runner-42)'));
+    assert.ok(body.includes('[Agent run](https://app.netlify.com/projects/example-site/agent-runs/runner-42)'));
     assert.ok(body.includes('<!-- netlify-agent-runner-id:runner-42 -->'));
     assert.ok(body.includes('<!-- netlify-agent-run-status -->'));
   });
@@ -149,7 +149,7 @@ describe('generate-error-comment', () => {
     });
 
     const body = await renderComment();
-    assert.ok(body.includes('Netlify Agent Runner failed'));
+    assert.ok(body.includes('Netlify Agent Runners run failed'));
     assert.ok(body.includes('- **Category:** `unknown`'));
   });
 
@@ -182,7 +182,7 @@ describe('generate-error-comment', () => {
     });
 
     const body = await renderComment();
-    assert.ok(body.includes('[Netlify Agents dashboard](https://app.netlify.com/projects/example-site/agent-runs)'));
+    assert.ok(body.includes('[Netlify Agent Runners dashboard](https://app.netlify.com/projects/example-site/agent-runs)'));
     assert.ok(body.includes('[GitHub Action logs](https://github.com/org/repo/actions/runs/99)'));
   });
 
@@ -195,7 +195,7 @@ describe('generate-error-comment', () => {
     });
 
     const body = await renderComment();
-    assert.ok(body.includes('[Netlify agent run](https://app.netlify.com/projects/example-site/agent-runs/runner-120)'));
+    assert.ok(body.includes('[Agent run](https://app.netlify.com/projects/example-site/agent-runs/runner-120)'));
     assert.ok(body.includes('[GitHub Action logs](https://github.com/org/repo/actions/runs/120)'));
     assert.ok(body.includes('<!-- netlify-agent-runner-id:runner-120 -->'));
     assert.ok(body.includes('<!-- netlify-agent-run-status -->'));

--- a/src/generate-history-comment.js
+++ b/src/generate-history-comment.js
@@ -39,7 +39,7 @@ module.exports = async function generateHistoryComment({ context, core }) {
   }
 
   const agentRunUrl = `https://app.netlify.com/projects/${siteName}/agent-runs/${agentId}`;
-  let message = `### Netlify Agent Run History\n\nView the full history in [Netlify Agent Run dashboard](${agentRunUrl})\n\n---\n\n`;
+  let message = `### Agent Run History\n\nView the full history in the [Netlify Agent Runners dashboard](${agentRunUrl})\n\n---\n\n`;
 
   const reversed = [...sessions].reverse();
   reversed.forEach((session, idx) => {
@@ -75,7 +75,7 @@ module.exports = async function generateHistoryComment({ context, core }) {
       /** @type {string[]} */
       const links = [];
       if (deployUrl) links.push(`[Open Preview URL](${deployUrl})`);
-      links.push(`[Netlify Agents run](${agentRunUrl})`);
+      links.push(`[Agent run](${agentRunUrl})`);
       if (commitSha && prUrl) {
         const prNum = prUrl.match(/\/pull\/(\d+)/);
         if (prNum) {

--- a/src/generate-step-summary.js
+++ b/src/generate-step-summary.js
@@ -146,12 +146,16 @@ function normalizeStepSummaryInput(source = {}) {
   const issueNumber = toText(
     source.issueNumber || source.issue || source.ISSUE_NUM || source.ISSUE_NUMBER
   ).trim();
+  const selectedAgent = toText(
+    source.agent || source.AGENT || source.NETLIFY_AGENT || source.model || source.MODEL
+  ).trim() || 'codex';
 
   return createStepSummaryInput({
     outcome,
     eventName,
     contextLabel: inferContextLabel(source),
-    model: toText(source.model || source.MODEL).trim() || 'codex',
+    agent: selectedAgent,
+    model: selectedAgent,
     isDryRun: toBool(source.isDryRun || source.IS_DRY_RUN),
     isPreflightOnly: toBool(source.isPreflightOnly || source.IS_PREFLIGHT_ONLY),
     issueNumber,
@@ -202,13 +206,13 @@ function renderTableSection(title, rows) {
 function renderStepSummary(source = {}) {
   const normalized = normalizeStepSummaryInput(source);
   const timeoutMinutes = toInt(source.timeoutMinutes || source.TIMEOUT_MINUTES);
-  let markdown = '# Netlify Agent Runner\n\n';
+  let markdown = '# Netlify Agent Runners\n\n';
 
   markdown += renderTableSection('Run Overview', [
     ['Outcome', normalized.outcome || 'unknown'],
     ['Event', normalized.eventName || 'unknown'],
     ['Context', normalized.contextLabel || 'n/a'],
-    ['Model', normalized.model || 'codex'],
+    ['Agent', normalized.agent || normalized.model || 'codex'],
     ['Dry-run', normalized.isDryRun ? 'true' : 'false'],
     ['Preflight-only', normalized.isPreflightOnly ? 'true' : 'false'],
   ]);
@@ -234,7 +238,7 @@ function renderStepSummary(source = {}) {
   }
 
   if (normalized.isPreflightOnly) {
-    markdown += '> Preflight-only mode: configuration was validated without starting a Netlify agent run.\n\n';
+    markdown += '> Preflight-only mode: configuration was validated without starting an agent run.\n\n';
   }
 
   if (normalized.outcome === 'timeout') {

--- a/src/generate-step-summary.test.js
+++ b/src/generate-step-summary.test.js
@@ -7,7 +7,7 @@ const {
 } = require('./generate-step-summary');
 
 describe('renderStepSummary', () => {
-  it('renders success run overview, model, runner, and links', () => {
+  it('renders success run overview, agent, runner, and links', () => {
     const markdown = renderStepSummary({
       outcome: 'success',
       eventName: 'issue_comment',
@@ -24,7 +24,7 @@ describe('renderStepSummary', () => {
 
     assert.ok(markdown.includes('| Outcome | success |'));
     assert.ok(markdown.includes('| Context | PR #42 |'));
-    assert.ok(markdown.includes('| Model | codex |'));
+    assert.ok(markdown.includes('| Agent | codex |'));
     assert.ok(markdown.includes('runner-123'));
     assert.ok(markdown.includes('[Open deploy](https://example-site.netlify.app)'));
     assert.ok(markdown.includes('[Open PR](https://github.com/o/r/pull/9)'));
@@ -80,7 +80,7 @@ describe('renderStepSummary', () => {
       },
     });
 
-    assert.ok(markdown.includes('Preflight-only mode: configuration was validated without starting a Netlify agent run.'));
+    assert.ok(markdown.includes('Preflight-only mode: configuration was validated without starting an agent run.'));
     assert.ok(markdown.includes('## Preflight Checks'));
     assert.ok(markdown.includes('| netlify-auth-token | pass | Token input is present |'));
     assert.ok(markdown.includes('| netlify-site-id | pass | Site ID input is present |'));
@@ -111,7 +111,8 @@ describe('normalizeStepSummaryInput', () => {
       GITHUB_EVENT_NAME: 'issue_comment',
       IS_PR: 'true',
       ISSUE_NUM: '55',
-      MODEL: 'claude',
+      AGENT: 'claude',
+      MODEL: 'legacy-codex',
       AGENT_ID: 'abc123',
       SITE_NAME: 'my-site',
       AGENT_RUN_URL: 'https://app.netlify.com/projects/my-site/agent-runs/abc123',

--- a/src/generate-success-comment.js
+++ b/src/generate-success-comment.js
@@ -73,7 +73,7 @@ module.exports = async function generateSuccessComment({ context, core }) {
   const agentRunUrl = `https://app.netlify.com/projects/${siteName}/agent-runs/${agentId}`;
 
   const dryRunTag = isDryRun ? ' (preview)' : '';
-  let message = `### [Netlify Agent Runner completed${dryRunTag}](${agentRunUrl}) ✅\n\n`;
+  let message = `### [Netlify Agent Runners run completed${dryRunTag}](${agentRunUrl}) ✅\n\n`;
 
   if (isDryRun) {
     message += `> **Preview mode** — no PR was created and no commits were made.\n\n`;
@@ -91,7 +91,7 @@ module.exports = async function generateSuccessComment({ context, core }) {
   /** @type {string[]} */
   const links = [];
   if (agentDeployUrl) links.push(`[Open Preview URL](${agentDeployUrl})`);
-  links.push(`[Netlify Agents run](${agentRunUrl})`);
+  links.push(`[Agent run](${agentRunUrl})`);
   if (agentCommitSha && agentPrUrl) {
     const prNum = agentPrUrl.match(/\/pull\/(\d+)/);
     if (prNum) {

--- a/src/get-context.js
+++ b/src/get-context.js
@@ -1,6 +1,6 @@
 // Extract context information from the GitHub event.
 // Sets outputs: issue-number, pr-number, head-ref, base-ref, head-sha,
-//               is-pr, trigger-text, has-linked-pr, model, is-dry-run
+//               is-pr, trigger-text, has-linked-pr, agent, model, is-dry-run
 
 /** @typedef {import('./types').ActionParams} ActionParams */
 
@@ -11,7 +11,7 @@ const utils = require('./utils');
  * @returns {Promise<void>}
  */
 module.exports = async function getContext({ github, context, core }) {
-  const defaultModel = process.env.DEFAULT_MODEL || 'codex';
+  const defaultAgent = process.env.DEFAULT_AGENT || process.env.DEFAULT_MODEL || 'codex';
 
   /** @type {number | undefined} */
   let issueNumber;
@@ -119,12 +119,13 @@ module.exports = async function getContext({ github, context, core }) {
   const isDryRun = process.env.DRY_RUN === 'true' ||
     /\b(?:preview|dry[- ]?run)\b/i.test(triggerText.split('\n')[0] || '');
 
-  // Extract model
-  let model = defaultModel;
-  if (context.eventName === 'workflow_dispatch' && payload.inputs?.model) {
-    model = payload.inputs.model.toLowerCase();
+  // Extract selected agent. `model` remains an output alias for compatibility.
+  let agent = defaultAgent;
+  const workflowDispatchAgent = payload.inputs?.agent || payload.inputs?.model;
+  if (context.eventName === 'workflow_dispatch' && workflowDispatchAgent) {
+    agent = workflowDispatchAgent.toLowerCase();
   } else {
-    model = utils.extractModel(triggerText, defaultModel);
+    agent = utils.extractModel(triggerText, defaultAgent);
   }
 
   // Append source URL for back-linking
@@ -151,8 +152,9 @@ module.exports = async function getContext({ github, context, core }) {
   core.setOutput('is-pr', isPR.toString());
   core.setOutput('trigger-text', triggerText);
   core.setOutput('has-linked-pr', hasLinkedPR.toString());
-  core.setOutput('model', model);
+  core.setOutput('agent', agent);
+  core.setOutput('model', agent);
   core.setOutput('is-dry-run', isDryRun.toString());
 
-  console.log(`Context: event=${context.eventName} issue=#${issueNumber} isPR=${isPR} model=${model} dryRun=${isDryRun}`);
+  console.log(`Context: event=${context.eventName} issue=#${issueNumber} isPR=${isPR} agent=${agent} dryRun=${isDryRun}`);
 };

--- a/src/get-context.test.js
+++ b/src/get-context.test.js
@@ -23,6 +23,7 @@ describe('getContext', () => {
   let core;
   beforeEach(() => {
     core = mockCore();
+    delete process.env.DEFAULT_AGENT;
     process.env.DEFAULT_MODEL = 'codex';
     process.env.DRY_RUN = 'false';
   });
@@ -39,6 +40,7 @@ describe('getContext', () => {
     await getContext({ github: mockGithub(), context, core });
     assert.equal(core.outputs['issue-number'], 42);
     assert.equal(core.outputs['is-pr'], 'true');
+    assert.equal(core.outputs['agent'], 'claude');
     assert.equal(core.outputs['model'], 'claude');
     assert.equal(core.outputs['is-dry-run'], 'false');
   });
@@ -151,10 +153,25 @@ describe('getContext', () => {
       repo: { owner: 'o', repo: 'r' },
     };
     await getContext({ github: mockGithub(), context, core });
+    assert.equal(core.outputs['agent'], 'gemini');
     assert.equal(core.outputs['model'], 'gemini');
   });
 
-  it('defaults model to DEFAULT_MODEL env', async () => {
+  it('uses workflow_dispatch agent input', async () => {
+    const context = {
+      eventName: 'workflow_dispatch',
+      payload: {
+        inputs: { trigger_text: 'build something', agent: 'claude' },
+      },
+      repo: { owner: 'o', repo: 'r' },
+    };
+    await getContext({ github: mockGithub(), context, core });
+    assert.equal(core.outputs['agent'], 'claude');
+    assert.equal(core.outputs['model'], 'claude');
+  });
+
+  it('defaults agent to DEFAULT_AGENT env', async () => {
+    process.env.DEFAULT_AGENT = 'gemini';
     process.env.DEFAULT_MODEL = 'claude';
     const context = {
       eventName: 'issue_comment',
@@ -165,6 +182,22 @@ describe('getContext', () => {
       repo: { owner: 'o', repo: 'r' },
     };
     await getContext({ github: mockGithub(), context, core });
+    assert.equal(core.outputs['agent'], 'gemini');
+    assert.equal(core.outputs['model'], 'gemini');
+  });
+
+  it('defaults agent to legacy DEFAULT_MODEL env', async () => {
+    process.env.DEFAULT_MODEL = 'claude';
+    const context = {
+      eventName: 'issue_comment',
+      payload: {
+        issue: { number: 1, pull_request: null },
+        comment: { body: '@netlify build a page', html_url: 'https://github.com/o/r/issues/1#c' },
+      },
+      repo: { owner: 'o', repo: 'r' },
+    };
+    await getContext({ github: mockGithub(), context, core });
+    assert.equal(core.outputs['agent'], 'claude');
     assert.equal(core.outputs['model'], 'claude');
   });
 

--- a/src/preflight.js
+++ b/src/preflight.js
@@ -13,6 +13,7 @@ const DEFAULT_MODEL = 'codex';
  *   netlifyAuthToken: string,
  *   netlifySiteId: string,
  *   githubToken: string,
+ *   defaultAgent: string,
  *   defaultModel: string,
  *   timeoutMinutes: number,
  *   triggerText: string,
@@ -97,8 +98,15 @@ function normalizePreflightInput(source = {}) {
     netlifyAuthToken: pickText(source, ['netlifyAuthToken', 'NETLIFY_AUTH_TOKEN', 'netlify-auth-token']),
     netlifySiteId: pickText(source, ['netlifySiteId', 'NETLIFY_SITE_ID', 'netlify-site-id']),
     githubToken: pickText(source, ['githubToken', 'GITHUB_TOKEN', 'github-token']),
+    defaultAgent: (
+      pickText(source, ['defaultAgent', 'DEFAULT_AGENT', 'agent', 'AGENT', 'default-agent']).toLowerCase()
+      || pickText(source, ['defaultModel', 'DEFAULT_MODEL', 'model', 'MODEL', 'default-model']).toLowerCase()
+      || DEFAULT_MODEL
+    ),
     defaultModel: (
-      pickText(source, ['defaultModel', 'DEFAULT_MODEL', 'model', 'MODEL']).toLowerCase() || DEFAULT_MODEL
+      pickText(source, ['defaultAgent', 'DEFAULT_AGENT', 'agent', 'AGENT', 'default-agent']).toLowerCase()
+      || pickText(source, ['defaultModel', 'DEFAULT_MODEL', 'model', 'MODEL', 'default-model']).toLowerCase()
+      || DEFAULT_MODEL
     ),
     timeoutMinutes: toInt(source.timeoutMinutes ?? source.TIMEOUT_MINUTES ?? source['timeout-minutes']),
     triggerText: pickText(source, ['triggerText', 'TRIGGER_TEXT', 'prompt', 'PROMPT']),
@@ -222,17 +230,17 @@ async function runPreflight(source = {}, runtimeChecks = {}) {
     input.netlifySiteId ? null : { category: 'missing-site-id', stage: 'validate-env' }
   );
 
-  const validModel = VALID_MODELS.includes(input.defaultModel);
+  const validModel = VALID_MODELS.includes(input.defaultAgent);
   pushCheck(
     checks,
     warnings,
     failureDetails,
-    'default-model',
+    'default-agent',
     validModel ? 'pass' : 'fail',
     validModel
-      ? `Default model is valid (${input.defaultModel}).`
-      : `Invalid default model "${input.defaultModel}". Expected one of: ${VALID_MODELS.join(', ')}.`,
-    validModel ? null : { category: 'model-unavailable', stage: 'validate-env', error: input.defaultModel }
+      ? `Default agent is valid (${input.defaultAgent}).`
+      : `Invalid default agent "${input.defaultAgent}". Expected one of: ${VALID_MODELS.join(', ')}.`,
+    validModel ? null : { category: 'agent-unavailable', stage: 'validate-env', error: input.defaultAgent }
   );
 
   const validTimeout = Number.isInteger(input.timeoutMinutes) && input.timeoutMinutes > 0;

--- a/src/preflight.test.js
+++ b/src/preflight.test.js
@@ -8,6 +8,7 @@ describe('normalizePreflightInput', () => {
       NETLIFY_AUTH_TOKEN: 'ntlk_123',
       NETLIFY_SITE_ID: 'site_abc',
       GITHUB_TOKEN: 'ghs_123',
+      DEFAULT_AGENT: 'GEMINI',
       DEFAULT_MODEL: 'CLAUDE',
       TIMEOUT_MINUTES: '15',
       TRIGGER_TEXT: 'Ship it',
@@ -18,7 +19,8 @@ describe('normalizePreflightInput', () => {
     assert.equal(normalized.netlifyAuthToken, 'ntlk_123');
     assert.equal(normalized.netlifySiteId, 'site_abc');
     assert.equal(normalized.githubToken, 'ghs_123');
-    assert.equal(normalized.defaultModel, 'claude');
+    assert.equal(normalized.defaultAgent, 'gemini');
+    assert.equal(normalized.defaultModel, 'gemini');
     assert.equal(normalized.timeoutMinutes, 15);
     assert.equal(normalized.triggerText, 'Ship it');
     assert.equal(normalized.issueNumber, '42');
@@ -40,7 +42,7 @@ describe('runPreflight', () => {
       netlifyAuthToken: 'token',
       netlifySiteId: 'site-id',
       githubToken: 'gh-token',
-      defaultModel: 'codex',
+      defaultAgent: 'codex',
       timeoutMinutes: 10,
       triggerText: '@netlify fix it',
       issueNumber: '88',
@@ -54,7 +56,7 @@ describe('runPreflight', () => {
     const byId = Object.fromEntries(result.checks.map(check => [check.id, check]));
     assert.equal(byId['netlify-auth-token'].status, 'pass');
     assert.equal(byId['netlify-site-id'].status, 'pass');
-    assert.equal(byId['default-model'].status, 'pass');
+    assert.equal(byId['default-agent'].status, 'pass');
     assert.equal(byId['timeout-minutes'].status, 'pass');
     assert.equal(byId['github-token'].status, 'pass');
     assert.equal(byId['trigger-context'].status, 'pass');
@@ -68,7 +70,7 @@ describe('runPreflight', () => {
 
   it('fails missing required static inputs with taxonomy-compatible failures', async () => {
     const result = await runPreflight({
-      defaultModel: 'unsupported-model',
+      defaultAgent: 'unsupported-agent',
       timeoutMinutes: '0',
       commentsRequired: true,
     });
@@ -76,7 +78,7 @@ describe('runPreflight', () => {
     assert.equal(result.ok, false);
     assert.ok(result.failures.includes('missing-auth-token'));
     assert.ok(result.failures.includes('missing-site-id'));
-    assert.ok(result.failures.includes('model-unavailable'));
+    assert.ok(result.failures.includes('agent-unavailable'));
     assert.ok(result.failures.includes('github-permission-denied'));
     assert.ok(result.failures.includes('unknown'));
   });
@@ -86,7 +88,7 @@ describe('runPreflight', () => {
       netlifyAuthToken: 'token',
       netlifySiteId: 'site-id',
       githubToken: 'gh-token',
-      defaultModel: 'gemini',
+      defaultAgent: 'gemini',
       timeoutMinutes: 10,
       triggerText: 'manual run',
       eventName: 'workflow_dispatch',
@@ -104,7 +106,7 @@ describe('runPreflight', () => {
         netlifyAuthToken: 'token',
         netlifySiteId: 'site-id',
         githubToken: 'gh-token',
-        defaultModel: 'claude',
+        defaultAgent: 'claude',
         timeoutMinutes: 10,
         triggerText: 'please run',
         issueNumber: '3',
@@ -143,7 +145,7 @@ describe('runPreflight', () => {
         netlifyAuthToken: 'token',
         netlifySiteId: 'site-id',
         githubToken: 'gh-token',
-        defaultModel: 'codex',
+        defaultAgent: 'codex',
         timeoutMinutes: 10,
         triggerText: '@netlify build',
         issueNumber: '12',

--- a/src/scenario-harness.js
+++ b/src/scenario-harness.js
@@ -381,7 +381,8 @@ async function generateScenarioComment(scenario, context, outputs, failure, reco
   process.env.IS_PR = outputs['is-pr'] || 'false';
   process.env.ISSUE_NUMBER = issueNumber ? String(issueNumber) : '';
   process.env.TRIGGER_TEXT = outputs['trigger-text'] || toText((scenario.env || {}).TRIGGER_TEXT);
-  process.env.AGENT_MODEL = outputs.model || toText((scenario.env || {}).AGENT_MODEL || (scenario.env || {}).DEFAULT_MODEL || 'codex');
+  process.env.NETLIFY_AGENT = outputs.agent || outputs.model || toText((scenario.env || {}).NETLIFY_AGENT || (scenario.env || {}).AGENT_MODEL || (scenario.env || {}).DEFAULT_AGENT || (scenario.env || {}).DEFAULT_MODEL || 'codex');
+  process.env.AGENT_MODEL = process.env.NETLIFY_AGENT;
   process.env.AGENT_ID = toText((scenario.env || {}).AGENT_ID) || reconciled.runnerId;
   process.env.SITE_NAME = toText((scenario.env || {}).SITE_NAME) || 'agent-runner-action-example';
   process.env.IS_DRY_RUN = outputs['is-dry-run'] || toText((scenario.env || {}).DRY_RUN || 'false');
@@ -417,6 +418,7 @@ async function runScenario(scenario, options = {}) {
   const netlifyFixtures = normalizeFixtureMap(scenario.netlifyFixtures, repoRoot);
 
   const envPatch = {
+    DEFAULT_AGENT: 'codex',
     DEFAULT_MODEL: 'codex',
     DRY_RUN: 'false',
     RUNNER_TEMP: os.tmpdir(),
@@ -516,7 +518,8 @@ async function runScenario(scenario, options = {}) {
         eventName: context.eventName,
         isPr: outputs['is-pr'] || toText(payload.pull_request ? 'true' : 'false'),
         issueNumber: outputs['issue-number'] || toText((payload.issue && /** @type {any} */ (payload.issue).number) || ''),
-        model: outputs.model || toText((scenario.env || {}).DEFAULT_MODEL || 'codex'),
+        agent: outputs.agent || outputs.model || toText((scenario.env || {}).DEFAULT_AGENT || (scenario.env || {}).DEFAULT_MODEL || 'codex'),
+        model: outputs.model || outputs.agent || toText((scenario.env || {}).DEFAULT_MODEL || (scenario.env || {}).DEFAULT_AGENT || 'codex'),
         runnerId: reconciled.runnerId || toText((scenario.env || {}).AGENT_ID),
         siteName: toText((scenario.env || {}).SITE_NAME),
         dashboardUrl: reconciled.agentRunUrl,

--- a/src/scenario-harness.test.js
+++ b/src/scenario-harness.test.js
@@ -20,9 +20,10 @@ describe('scenario harness', () => {
 
     assert.equal(trace.outputs['should-run'], 'true');
     assert.equal(trace.outputs['is-pr'], 'false');
+    assert.equal(trace.outputs.agent, 'codex');
     assert.equal(trace.outputs.model, 'codex');
     assert.equal(trace.failures.length, 0);
-    assert.ok(trace.summary.includes('# Netlify Agent Runner'));
+    assert.ok(trace.summary.includes('# Netlify Agent Runners'));
     assert.ok(trace.summary.includes('| Outcome | success |'));
     assert.ok(trace.comments.length > 0);
   });
@@ -74,9 +75,9 @@ describe('scenario harness', () => {
     assert.equal(trace.state.reconciled.recoveryAction, 'redirect-to-pr');
   });
 
-  it('covers workflow_dispatch explicit model selection', async () => {
+  it('covers workflow_dispatch explicit agent selection', async () => {
     const trace = await runScenario({
-      name: 'workflow dispatch explicit model',
+      name: 'workflow dispatch explicit agent',
       eventName: 'workflow_dispatch',
       eventFixture: 'fixtures/events/workflow-dispatch.json',
       env: {
@@ -87,6 +88,7 @@ describe('scenario harness', () => {
     });
 
     assert.equal(trace.outputs['should-run'], 'true');
+    assert.equal(trace.outputs.agent, 'gemini');
     assert.equal(trace.outputs.model, 'gemini');
   });
 
@@ -183,8 +185,8 @@ describe('scenario harness', () => {
     });
 
     assert.equal(trace.failures.length, 1);
-    assert.equal(trace.failures[0].category, 'model-unavailable');
-    assert.ok(trace.summary.includes('`model-unavailable`'));
+    assert.equal(trace.failures[0].category, 'agent-unavailable');
+    assert.ok(trace.summary.includes('`agent-unavailable`'));
   });
 
   it('maps timeout runs to taxonomy and summary timeout section', async () => {
@@ -232,7 +234,7 @@ describe('scenario harness', () => {
     assert.equal(trace.failures.length, 0);
     assert.equal(trace.comments.length, 0);
     assert.ok(trace.summary.includes('Preview mode: no commit or pull request creation is performed.'));
-    assert.ok(trace.summary.includes('Preflight-only mode: configuration was validated without starting a Netlify agent run.'));
+    assert.ok(trace.summary.includes('Preflight-only mode: configuration was validated without starting an agent run.'));
     assert.ok(trace.summary.includes('Both dry-run=true and preflight-only=true were set; preflight-only takes precedence.'));
     assert.ok(trace.summary.includes('| Runner ID | n/a |'));
     assert.ok(trace.summary.includes('| Dashboard | n/a |'));

--- a/src/simulate.js
+++ b/src/simulate.js
@@ -52,6 +52,7 @@ const { loadFixtureJson, runScenario } = require('./scenario-harness');
  * @property {Outcome} outcome
  * @property {boolean} shouldRun
  * @property {SimulationContext} context
+ * @property {string} agent
  * @property {string} model
  * @property {string} prompt
  * @property {Record<string, unknown>} recoveredState
@@ -477,7 +478,8 @@ function buildReport(trace, meta) {
     outcome: meta.outcome,
     shouldRun,
     context,
-    model: toText(outputs.model),
+    agent: toText(outputs.agent || outputs.model),
+    model: toText(outputs.model || outputs.agent),
     prompt: toText(outputs['trigger-text']),
     recoveredState: { ...reconciled },
     warnings: Array.isArray(trace.warnings) ? trace.warnings.map(toText) : [],
@@ -515,7 +517,7 @@ function renderHumanReport(report) {
   lines.push(`Decision: ${report.decision}`);
   lines.push(`Should run: ${report.shouldRun ? 'true' : 'false'}`);
   lines.push(`Outcome: ${report.outcome}`);
-  lines.push(`Model: ${report.model || 'n/a'}`);
+  lines.push(`Agent: ${report.agent || report.model || 'n/a'}`);
   lines.push('');
 
   lines.push('Prompt:');
@@ -586,7 +588,7 @@ function renderMarkdownReport(report) {
   lines.push(`| Decision | \`${report.decision}\` |`);
   lines.push(`| Should run | ${report.shouldRun ? 'true' : 'false'} |`);
   lines.push(`| Outcome | \`${report.outcome}\` |`);
-  lines.push(`| Model | \`${report.model || 'n/a'}\` |`);
+  lines.push(`| Agent | \`${report.agent || report.model || 'n/a'}\` |`);
   lines.push('');
   lines.push('## Prompt');
   lines.push('');

--- a/src/simulate.test.js
+++ b/src/simulate.test.js
@@ -75,7 +75,7 @@ describe('simulate CLI', () => {
       assert.equal(result.report.context.prNumber, '58');
       assert.equal(result.report.recoveredState.runnerId, 'runner-state-123');
       assert.equal(result.report.recoveredState.recoveryAction, 'resume-runner');
-      assert.ok(result.report.summary.includes('# Netlify Agent Runner'));
+      assert.ok(result.report.summary.includes('# Netlify Agent Runners'));
       assert.ok(result.report.comments.length > 0);
     } finally {
       fs.rmSync(tempDir, { recursive: true, force: true });

--- a/src/state-reconciliation.js
+++ b/src/state-reconciliation.js
@@ -1,4 +1,4 @@
-// Reconcile prior Netlify Agent run state from comments, PR bodies, and outputs.
+// Reconcile prior agent run state from comments, PR bodies, and outputs.
 // Pure module: no API calls.
 
 /**

--- a/src/types.js
+++ b/src/types.js
@@ -1,4 +1,4 @@
-// Shared JSDoc type definitions for the Netlify Agents action.
+// Shared JSDoc type definitions for the Netlify Agent Runners action.
 // These are purely for editor IntelliSense and `tsc --checkJs` — no runtime cost.
 
 /**
@@ -49,7 +49,7 @@
  * @typedef {object} EventPayload
  * @property {{login: string}} [sender]
  * @property {{full_name: string}} [repository]
- * @property {{trigger_text?: string, actor?: string, model?: string}} [inputs]
+ * @property {{trigger_text?: string, actor?: string, agent?: string, model?: string}} [inputs]
  * @property {{number: number, body?: string, title?: string, html_url?: string, author_association?: string, pull_request?: {url?: string}}} [issue]
  * @property {{id: number, body?: string, html_url?: string, author_association?: string, user?: {login: string}}} [comment]
  * @property {{number: number, body?: string, html_url?: string, author_association?: string, head: {ref: string, sha: string, repo?: {full_name: string}}, base: {ref: string}}} [pull_request]
@@ -91,7 +91,7 @@
  */
 
 /**
- * A single Netlify Agent session from the API.
+ * A single Netlify Agent Runners session from the API.
  * @typedef {object} AgentSession
  * @property {string} id
  * @property {string} [prompt]

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,4 @@
-// Shared utilities for the Netlify Agents action.
+// Shared utilities for the Netlify Agent Runners action.
 // Used by actions/github-script steps via:
 //   const utils = require(`${process.env.ACTION_DIR}/src/utils.js`)
 
@@ -34,7 +34,7 @@ const TRIGGER_PATTERN = new RegExp(
 );
 
 // ---------------------------------------------------------------------------
-// Model handling
+// Agent selection handling. Legacy API fields still use the name "model".
 // ---------------------------------------------------------------------------
 
 /** @type {string[]} */
@@ -160,10 +160,10 @@ function buildInProgressComment({ agentRunUrl, prompt, model, runnerId, ghAction
   const clean = cleanPrompt(prompt);
 
   let body = agentRunUrl
-    ? `### [Netlify Agent Runner ${flavor}](${agentRunUrl}) ${emoji}\n\n`
-    : `### Netlify Agent Runner ${flavor} ${emoji}\n\n`;
+    ? `### [Netlify Agent Runners ${flavor}](${agentRunUrl}) ${emoji}\n\n`
+    : `### Netlify Agent Runners ${flavor} ${emoji}\n\n`;
 
-  body += `**Model:** \`${model}\`\n\n`;
+  body += `**Agent:** \`${model}\`\n\n`;
   if (clean) body += formatPromptBlock(clean);
 
   /** @type {string[]} */

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -170,7 +170,7 @@ describe('buildInProgressComment', () => {
     const result = utils.buildInProgressComment({
       prompt: '@netlify build it', model: 'codex'
     });
-    assert.ok(result.includes('Netlify Agent Runner'));
+    assert.ok(result.includes('Netlify Agent Runners'));
     assert.ok(result.includes('`codex`'));
     assert.ok(result.includes('<!-- netlify-agent-run-status -->'));
   });

--- a/workflow-templates/netlify-agents.properties.json
+++ b/workflow-templates/netlify-agents.properties.json
@@ -1,6 +1,6 @@
 {
-  "name": "Netlify Agents",
-  "description": "Trigger Netlify Agents from GitHub issues and pull requests using @netlify mentions.",
+  "name": "Netlify Agent Runners",
+  "description": "Start Netlify Agent Runners agent runs from GitHub issues and pull requests using @netlify mentions.",
   "iconName": "zap",
   "categories": ["Automation", "Deployment"]
 }

--- a/workflow-templates/netlify-agents.yml
+++ b/workflow-templates/netlify-agents.yml
@@ -1,4 +1,4 @@
-name: Netlify Agents
+name: Netlify Agent Runners
 
 on:
   workflow_dispatch:
@@ -12,8 +12,8 @@ on:
         description: 'GitHub username to attribute this run to'
         required: true
         type: string
-      model:
-        description: 'AI model to use'
+      agent:
+        description: 'Agent to use'
         required: false
         type: choice
         options:
@@ -57,10 +57,10 @@ jobs:
           netlify-auth-token: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           netlify-site-id: ${{ secrets.NETLIFY_SITE_ID }}
           # Optional settings:
-          # default-model: 'codex'        # Default AI model (claude, codex, gemini)
+          # default-agent: 'codex'        # Default agent (claude, codex, gemini)
           # manage-labels: 'false'        # Auto-create and apply labels
-          # dry-run: 'false'              # Still runs Netlify Agent; skips commit/PR creation
-          # preflight-only: 'false'       # Validate setup only; starts no agent runner
+          # dry-run: 'false'              # Still starts an agent run; skips commit/PR creation
+          # preflight-only: 'false'       # Validate setup only; starts no agent run
           # If both are true, preflight-only behavior wins.
           # preflight-only: 'true'        # Example: verify config/permissions and exit
           # dry-run: 'true'               # Example: run preview without committing changes


### PR DESCRIPTION
## Summary
- add preferred agent-oriented contracts: `default-agent`, output `agent`, `DEFAULT_AGENT` / `NETLIFY_AGENT`, and `agent-unavailable`
- preserve backward-compatible model-based aliases for existing users
- refresh docs, workflow templates, comments, tests, and canary wording around Netlify Agent Runners and agent runs

## Validation
- `bun test src/*.test.js`
- `bun run docs:check`
- `bunx tsc --noEmit`

## Canary
This PR touches `action.yml` and `src/**`, so the programmatic canary workflow should run on the pull request and verify the downstream canary issue flow.