### PR TITLE
Harden state reconciliation against untrusted-author markers

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -339,8 +339,26 @@ runs:
           core.setOutput('should-continue', shouldContinue ? 'true' : 'false');
 
     # -----------------------------------------------------------------------
-    # 5. Find or create the sticky status comment
+    # 5. Resolve bot identity, then find or create the sticky status comment.
+    #    The bot-identity step lets find-comment filter to comments authored by
+    #    the same identity that posts our status updates, preventing comment
+    #    poisoning from arbitrary users (see SECURITY.md).
     # -----------------------------------------------------------------------
+    - name: Resolve bot identity
+      id: bot-identity
+      if: steps.trigger-check.outputs.should-run == 'true' && github.event_name != 'workflow_dispatch'
+      uses: actions/github-script@v8
+      with:
+        github-token: ${{ inputs.github-token }}
+        script: |
+          try {
+            const { data } = await github.rest.users.getAuthenticated();
+            core.setOutput('login', data.login);
+          } catch (error) {
+            console.log(`Bot identity lookup failed, falling back to github-actions[bot]: ${error.message}`);
+            core.setOutput('login', 'github-actions[bot]');
+          }
+
     - name: Find existing status comment
       if: steps.trigger-check.outputs.should-run == 'true' && github.event_name != 'workflow_dispatch' && steps.context-info.outputs.issue-number != ''
       uses: peter-evans/find-comment@v4
@@ -349,6 +367,8 @@ runs:
         token: ${{ inputs.github-token }}
         issue-number: ${{ steps.context-info.outputs.issue-number }}
         body-includes: '<!-- netlify-agent-run-status -->'
+        comment-author: ${{ steps.bot-identity.outputs.login }}
+        direction: last
 
     - name: Find existing history comment
       if: steps.trigger-check.outputs.should-run == 'true' && github.event_name != 'workflow_dispatch' && steps.context-info.outputs.is-pr == 'true'
@@ -357,6 +377,8 @@ runs:
       with:
         token: ${{ inputs.github-token }}
         issue-number: ${{ steps.context-info.outputs.issue-number }}
+        comment-author: ${{ steps.bot-identity.outputs.login }}
+        direction: last
         body-includes: '<!-- netlify-agent-run-history -->'
 
     - name: Extract existing agent run ID
@@ -775,12 +797,19 @@ runs:
         # Create or reuse agent run
         if [ -n "${EXISTING_RUNNER_ID:-}" ]; then
           echo "🔄 Follow-up session on runner: $EXISTING_RUNNER_ID"
-          SAFE_PROMPT=$(echo "$TRIGGER_TEXT" | jq -Rs .)
+          # Build the JSON payload with jq so every value is properly escaped.
+          # Direct bash interpolation here would let any special character in
+          # EXISTING_RUNNER_ID smuggle additional JSON keys.
+          SESSION_PAYLOAD=$(jq -n \
+            --arg id "$EXISTING_RUNNER_ID" \
+            --arg agent "$SELECTED_AGENT" \
+            --arg prompt "$TRIGGER_TEXT" \
+            '{agent_runner_id: $id, body: {prompt: $prompt, agent: $agent}}')
           SESSION_CREATED=false
           for ATTEMPT in 1 2 3; do
             echo "  Attempt $ATTEMPT/3..."
             SESSION_RESULT=$(netlify api createAgentRunnerSession \
-              --data "{\"agent_runner_id\": \"$EXISTING_RUNNER_ID\", \"body\": {\"prompt\": $SAFE_PROMPT, \"agent\": \"$SELECTED_AGENT\"}}" 2>/dev/null || true)
+              --data "$SESSION_PAYLOAD" 2>/dev/null || true)
             debug_log "createAgentRunnerSession (attempt $ATTEMPT)" "$SESSION_RESULT"
             SESSION_STATE=$(echo "$SESSION_RESULT" | jq -r '.state // empty')
             if [ "$SESSION_STATE" = "running" ]; then

--- a/src/comment-markers.js
+++ b/src/comment-markers.js
@@ -6,6 +6,57 @@ const RUNNER_ID_MARKER_PREFIX = '<!-- netlify-agent-runner-id:';
 const SESSION_DATA_MARKER_PREFIX = '<!-- netlify-agent-session-data:';
 const MARKER_SUFFIX = '-->';
 
+// Conservative format for runner IDs: alphanumerics, underscore, hyphen only.
+// Rejects characters that could break JSON construction (quotes, backslashes),
+// shell argument boundaries, or Markdown link syntax.
+const RUNNER_ID_FORMAT = /^[A-Za-z0-9_-]{1,128}$/;
+
+// Allowlist of HTML comments the action recognizes. Any other HTML comment
+// found in user-influenced content is stripped before parsing/rendering, so
+// outsiders cannot smuggle fake markers and bot comments cannot accidentally
+// reflect attacker-supplied markers from echoed user content.
+const ALLOWED_MARKER_INNER = /^\s*netlify-agent-(?:run-status|run-history|runner-id:|session-data:)/;
+
+// Allowlist for URL-bearing fields in session-data entries. These URLs flow
+// into bot-rendered Markdown links; anything outside these patterns gets
+// dropped at parse time so phishing links cannot ride through poisoned state.
+const SESSION_URL_ALLOWLIST = {
+  pr_url:        /^https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/pull\/\d+(?:[/?#].*)?$/,
+  gh_action_url: /^https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/actions\/runs\/\d+(?:[/?#].*)?$/,
+  screenshot:    /^https:\/\/(?:[A-Za-z0-9-]+\.)*(?:netlify\.app|netlifyusercontent\.com|app\.netlify\.com|api\.netlify\.com)\/[^\s]*$/i,
+};
+// 4 covers git's minimum unique-prefix display; 64 covers full SHA-256.
+const COMMIT_SHA_FORMAT = /^[0-9a-f]{4,64}$/i;
+const SESSION_FIELD_MAX_LENGTH = 2048;
+
+/**
+ * Drop URL/sha fields that don't match their format. Mutates a copy.
+ * @param {Record<string, unknown>} entry
+ * @returns {Record<string, unknown>}
+ */
+function sanitizeSessionEntry(entry) {
+  /** @type {Record<string, unknown>} */
+  const out = {};
+  for (const [key, value] of Object.entries(entry)) {
+    if (typeof value !== 'string') {
+      // Non-string values aren't currently expected; keep them only if scalar.
+      if (value === null || typeof value === 'number' || typeof value === 'boolean') {
+        out[key] = value;
+      }
+      continue;
+    }
+    if (value.length > SESSION_FIELD_MAX_LENGTH) continue;
+    const allowlist = /** @type {Record<string, RegExp>} */ (SESSION_URL_ALLOWLIST);
+    if (Object.prototype.hasOwnProperty.call(allowlist, key)) {
+      if (!allowlist[key].test(value)) continue;
+    } else if (key === 'commit_sha') {
+      if (!COMMIT_SHA_FORMAT.test(value)) continue;
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
 /**
  * @param {unknown} body
  * @returns {string}
@@ -77,7 +128,10 @@ function renderRunnerIdMarker(runnerId = '') {
  * @returns {string}
  */
 function parseRunnerId(body) {
-  return readMarkerValue(body, RUNNER_ID_MARKER_PREFIX);
+  const value = readMarkerValue(body, RUNNER_ID_MARKER_PREFIX);
+  if (!value) return '';
+  if (!RUNNER_ID_FORMAT.test(value)) return '';
+  return value;
 }
 
 /**
@@ -98,11 +152,21 @@ function parseSessionData(body) {
   const rawValue = readMarkerValue(body, SESSION_DATA_MARKER_PREFIX);
   if (!rawValue) return {};
 
+  /** @type {Record<string, unknown>} */
+  let map;
   try {
-    return normalizeSessionDataMap(JSON.parse(rawValue));
+    map = normalizeSessionDataMap(JSON.parse(rawValue));
   } catch (_) {
     return {};
   }
+
+  /** @type {Record<string, unknown>} */
+  const sanitized = {};
+  for (const [sessionId, entry] of Object.entries(map)) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue;
+    sanitized[sessionId] = sanitizeSessionEntry(/** @type {Record<string, unknown>} */ (entry));
+  }
+  return sanitized;
 }
 
 /**
@@ -122,6 +186,39 @@ function parseLinkedPrReference(body) {
   return '';
 }
 
+/**
+ * Remove every HTML comment that is not one of our allowlisted markers.
+ * Used on the read path: sanitize comment/PR-body text before parsing markers,
+ * so a poisoned non-bot comment cannot inject runner-id/session-data values
+ * even if it slipped past upstream author filtering.
+ *
+ * @param {unknown} body
+ * @returns {string}
+ */
+function stripUntrustedHtmlComments(body) {
+  const text = normalizeBody(body);
+  if (!text) return '';
+  return text.replace(/<!--([\s\S]*?)-->/g, (match, inner) => {
+    return ALLOWED_MARKER_INNER.test(inner) ? match : '';
+  });
+}
+
+/**
+ * Remove every HTML comment unconditionally. Used on the write path when
+ * embedding user-authored content (issue/PR/comment bodies) into a
+ * bot-authored comment, so the bot's output never reflects user-supplied
+ * markers — even ones shaped like ours, which a later parser's indexOf would
+ * pick up before the bot's own legitimate marker at the end of the body.
+ *
+ * @param {unknown} body
+ * @returns {string}
+ */
+function stripAllHtmlComments(body) {
+  const text = normalizeBody(body);
+  if (!text) return '';
+  return text.replace(/<!--[\s\S]*?-->/g, '');
+}
+
 module.exports = {
   STATUS_COMMENT_MARKER,
   HISTORY_COMMENT_MARKER,
@@ -132,4 +229,6 @@ module.exports = {
   renderSessionDataMarker,
   parseSessionData,
   parseLinkedPrReference,
+  stripUntrustedHtmlComments,
+  stripAllHtmlComments,
 };

--- a/src/comment-markers.test.js
+++ b/src/comment-markers.test.js
@@ -74,6 +74,101 @@ describe('parseSessionData', () => {
   });
 });
 
+describe('parseRunnerId format validation', () => {
+  it('accepts alphanumeric, underscore, hyphen ids', () => {
+    assert.equal(markers.parseRunnerId('<!-- netlify-agent-runner-id:runner_abc-123 -->'), 'runner_abc-123');
+  });
+
+  it('rejects ids containing JSON-breaking characters', () => {
+    const body = '<!-- netlify-agent-runner-id:x","prompt":"smuggled -->';
+    assert.equal(markers.parseRunnerId(body), '');
+  });
+
+  it('rejects ids with whitespace or newlines', () => {
+    assert.equal(markers.parseRunnerId('<!-- netlify-agent-runner-id:has space -->'), '');
+    assert.equal(markers.parseRunnerId('<!-- netlify-agent-runner-id:has\nnewline -->'), '');
+  });
+
+  it('rejects empty values from a present marker', () => {
+    assert.equal(markers.parseRunnerId('<!-- netlify-agent-runner-id: -->'), '');
+  });
+
+  it('rejects ids longer than 128 characters', () => {
+    const long = 'a'.repeat(129);
+    assert.equal(markers.parseRunnerId(`<!-- netlify-agent-runner-id:${long} -->`), '');
+  });
+});
+
+describe('parseSessionData url allowlist', () => {
+  it('keeps allowlisted github pull and action URLs', () => {
+    const body = '<!-- netlify-agent-session-data:' + JSON.stringify({
+      s1: {
+        pr_url: 'https://github.com/org/repo/pull/12',
+        gh_action_url: 'https://github.com/org/repo/actions/runs/345',
+      },
+    }) + ' -->';
+    assert.deepEqual(markers.parseSessionData(body), {
+      s1: {
+        pr_url: 'https://github.com/org/repo/pull/12',
+        gh_action_url: 'https://github.com/org/repo/actions/runs/345',
+      },
+    });
+  });
+
+  it('drops url fields that point off-domain', () => {
+    const body = '<!-- netlify-agent-session-data:' + JSON.stringify({
+      s1: {
+        pr_url: 'https://evil.com/phish',
+        gh_action_url: 'https://attacker.example/runs/9',
+      },
+    }) + ' -->';
+    assert.deepEqual(markers.parseSessionData(body), { s1: {} });
+  });
+
+  it('keeps screenshot urls only on netlify-owned hosts', () => {
+    const okBody = '<!-- netlify-agent-session-data:' + JSON.stringify({
+      s1: { screenshot: 'https://my-site.netlify.app/preview/1.png' },
+    }) + ' -->';
+    assert.deepEqual(markers.parseSessionData(okBody), {
+      s1: { screenshot: 'https://my-site.netlify.app/preview/1.png' },
+    });
+
+    const badBody = '<!-- netlify-agent-session-data:' + JSON.stringify({
+      s1: { screenshot: 'https://evil.com/preview/1.png' },
+    }) + ' -->';
+    assert.deepEqual(markers.parseSessionData(badBody), { s1: {} });
+  });
+});
+
+describe('stripUntrustedHtmlComments', () => {
+  it('keeps allowlisted netlify markers and drops everything else', () => {
+    const input = [
+      '<!-- something else -->',
+      '<!-- netlify-agent-run-status -->',
+      '<!-- netlify-agent-runner-id:abc -->',
+      '<!-- evil -->',
+    ].join('\n');
+    const out = markers.stripUntrustedHtmlComments(input);
+    assert.ok(out.includes('<!-- netlify-agent-run-status -->'));
+    assert.ok(out.includes('<!-- netlify-agent-runner-id:abc -->'));
+    assert.ok(!out.includes('something else'));
+    assert.ok(!out.includes('evil'));
+  });
+});
+
+describe('stripAllHtmlComments', () => {
+  it('removes every html comment, allowlist or not', () => {
+    const input = '<!-- netlify-agent-run-status -->keep<!-- foo -->me';
+    assert.equal(markers.stripAllHtmlComments(input), 'keepme');
+  });
+
+  it('blocks attacker-shaped marker injection in user content', () => {
+    const userPrompt = 'Please fix this.\n<!-- netlify-agent-runner-id:planted -->\nThanks';
+    const out = markers.stripAllHtmlComments(userPrompt);
+    assert.ok(!out.includes('netlify-agent-runner-id'));
+  });
+});
+
 describe('parseLinkedPrReference', () => {
   it('extracts PR numbers from plain reference lines', () => {
     assert.equal(markers.parseLinkedPrReference('Changes in Pull Request #42'), '42');

--- a/src/extract-agent-id.js
+++ b/src/extract-agent-id.js
@@ -2,7 +2,7 @@
 // Sets outputs: agent-runner-id, session-data-map, agent-run-url, has-linked-pr, linked-pr-number
 
 /** @typedef {import('./types').ActionParams} ActionParams */
-const { RUNNER_ID_MARKER_PREFIX } = require('./comment-markers');
+const { RUNNER_ID_MARKER_PREFIX, stripUntrustedHtmlComments } = require('./comment-markers');
 const { reconcileAgentState } = require('./state-reconciliation');
 
 /**
@@ -24,19 +24,28 @@ module.exports = async function extractAgentId({ github, context, core, inputs }
     statusCommentBody = comment.data.body || '';
   }
 
-  // Fallback for PRs: check PR body
+  // Fallback for PRs: check PR body, but ONLY for same-repo PRs.
+  // Fork PR bodies are authored by external contributors and must not be
+  // trusted as durable state — see SECURITY.md (comment-state poisoning).
   if (!statusCommentBody.includes(RUNNER_ID_MARKER_PREFIX) && isPR && prNumber) {
     const pr = await github.rest.pulls.get({
       owner: context.repo.owner, repo: context.repo.repo,
       pull_number: parseInt(prNumber)
     });
-    prBody = pr.data.body || '';
+    const headRepo = pr.data.head && pr.data.head.repo && pr.data.head.repo.full_name;
+    const baseRepo = pr.data.base && pr.data.base.repo && pr.data.base.repo.full_name;
+    const isSameRepo = !!headRepo && !!baseRepo && headRepo === baseRepo;
+    if (isSameRepo) {
+      prBody = pr.data.body || '';
+    } else {
+      console.log(`Skipping PR body fallback for fork PR (head=${headRepo || '?'}, base=${baseRepo || '?'})`);
+    }
   }
 
   const reconciled = reconcileAgentState({
     isPr: isPR,
-    statusCommentBody,
-    prBody,
+    statusCommentBody: stripUntrustedHtmlComments(statusCommentBody),
+    prBody: stripUntrustedHtmlComments(prBody),
   });
 
   if (reconciled.warnings.length > 0) {

--- a/src/extract-agent-id.test.js
+++ b/src/extract-agent-id.test.js
@@ -10,14 +10,22 @@ function mockCore() {
   };
 }
 
-function mockGithub({ commentBody = '', prBody = '' } = {}) {
+function mockGithub({ commentBody = '', prBody = '', isFork = false } = {}) {
+  const baseRepo = { full_name: 'owner/repo' };
+  const headRepo = isFork ? { full_name: 'forker/repo' } : baseRepo;
   return {
     rest: {
       issues: {
         getComment: async () => ({ data: { body: commentBody } }),
       },
       pulls: {
-        get: async () => ({ data: { body: prBody } }),
+        get: async () => ({
+          data: {
+            body: prBody,
+            head: { repo: headRepo },
+            base: { repo: baseRepo },
+          },
+        }),
       },
     },
   };
@@ -88,6 +96,41 @@ describe('extractAgentId', () => {
 
     assert.equal(core.outputs['agent-runner-id'], 'runner-from-pr');
     assert.equal(core.outputs['session-data-map'], '{}');
+  });
+
+  it('ignores PR body markers on fork PRs to prevent state poisoning', async () => {
+    const core = mockCore();
+    const github = mockGithub({
+      commentBody: 'status body without markers',
+      prBody: '<!-- netlify-agent-runner-id:planted-by-fork -->',
+      isFork: true,
+    });
+
+    await extractAgentId({
+      github,
+      context: context(),
+      core,
+      inputs: { isPR: 'true', commentId: '21', prNumber: '21' },
+    });
+
+    assert.equal(core.outputs['agent-runner-id'], '');
+    assert.ok(logs.some(line => line.includes('Skipping PR body fallback for fork PR')));
+  });
+
+  it('rejects malformed runner-id markers that contain JSON-breaking characters', async () => {
+    const core = mockCore();
+    const github = mockGithub({
+      commentBody: '<!-- netlify-agent-runner-id:x","prompt":"smuggled -->',
+    });
+
+    await extractAgentId({
+      github,
+      context: context(),
+      core,
+      inputs: { isPR: 'false', commentId: '40', prNumber: '' },
+    });
+
+    assert.equal(core.outputs['agent-runner-id'], '');
   });
 
   it('sets linked-pr outputs from reconciled state', async () => {

--- a/src/types.js
+++ b/src/types.js
@@ -36,7 +36,7 @@
  * @property {(params: {owner: string, repo: string, name: string, color: string, description: string}) => Promise<{data: {id: number, name: string}}>} rest.issues.createLabel
  * @property {(params: {owner: string, repo: string, issue_number: number, per_page: number, headers?: Record<string, string>}) => Promise<{data: TimelineEvent[]}>} rest.issues.listEventsForTimeline
  * @property {object} rest.pulls
- * @property {(params: {owner: string, repo: string, pull_number: number}) => Promise<{data: {head: {ref: string, sha: string}, base: {ref: string}, body?: string}}>} rest.pulls.get
+ * @property {(params: {owner: string, repo: string, pull_number: number}) => Promise<{data: {head: {ref: string, sha: string, repo?: {full_name: string}}, base: {ref: string, repo?: {full_name: string}}, body?: string}}>} rest.pulls.get
  * @property {object} rest.repos
  * @property {(params: {owner: string, repo: string, username: string}) => Promise<{data: {permission: string}}>} rest.repos.getCollaboratorPermissionLevel
  * @property {object} rest.reactions

--- a/src/utils.js
+++ b/src/utils.js
@@ -56,13 +56,34 @@ const MODEL_PATTERN = new RegExp(
 // ---------------------------------------------------------------------------
 
 /**
+ * Strip Markdown code regions (fenced blocks and inline code spans) from text
+ * so trigger detection ignores @netlify mentions a user is quoting verbatim.
+ *
+ * Handles:
+ *   - ```fenced``` and ~~~fenced~~~ blocks
+ *   - `inline` and ``inline with backtick`` spans (any number of paired backticks)
+ *
+ * @param {string} text
+ * @returns {string}
+ */
+function stripMarkdownCode(text) {
+  if (!text) return '';
+  return text
+    .replace(/```[\s\S]*?```/g, '')
+    .replace(/~~~[\s\S]*?~~~/g, '')
+    .replace(/(`+)[\s\S]*?\1/g, '');
+}
+
+/**
  * Check whether `text` contains any recognised trigger mention.
+ * Mentions inside Markdown code spans or fenced blocks are ignored so users
+ * can quote `@netlify` verbatim without firing the action.
  * @param {string | null | undefined} text
  * @returns {boolean}
  */
 function matchesTrigger(text) {
   if (!text) return false;
-  return TRIGGER_PATTERN.test(text);
+  return TRIGGER_PATTERN.test(stripMarkdownCode(text));
 }
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -5,7 +5,11 @@
 /** @typedef {import('./types').InProgressCommentOptions} InProgressCommentOptions */
 
 const path = require('path');
-const { STATUS_COMMENT_MARKER, renderRunnerIdMarker } = require('./comment-markers');
+const {
+  STATUS_COMMENT_MARKER,
+  renderRunnerIdMarker,
+  stripAllHtmlComments,
+} = require('./comment-markers');
 
 /** @type {[string, string][]} */
 const FLAVOR_MESSAGES = require(path.join(__dirname, 'flavor-messages.json'));
@@ -118,6 +122,11 @@ function ghContainsExpressions(field) {
  * @returns {string}
  */
 function formatPromptBlock(prompt, sourceUrl) {
+  if (!prompt) return '';
+  // Strip every HTML comment the user may have included so attacker-controlled
+  // markers — even ones shaped like ours — can never be reflected into a
+  // bot-authored comment body.
+  prompt = stripAllHtmlComments(prompt);
   if (!prompt) return '';
   const MAX_LENGTH = 350;
   let display = prompt;

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -49,6 +49,29 @@ describe('matchesTrigger', () => {
   it('matches trigger mid-text', () => {
     assert.ok(utils.matchesTrigger('please @netlify build a page'));
   });
+
+  it('ignores @netlify mentions inside inline code spans', () => {
+    assert.ok(!utils.matchesTrigger('See `@netlify` documentation for context'));
+    assert.ok(!utils.matchesTrigger('the ``@netlify`` token is a marker'));
+    assert.ok(!utils.matchesTrigger('one `@netlify` and another `@netlify` quoted'));
+  });
+
+  it('ignores @netlify mentions inside fenced code blocks', () => {
+    const fenced = [
+      'Here is some yaml:',
+      '```yaml',
+      'on: issue_comment # @netlify',
+      '```',
+    ].join('\n');
+    assert.ok(!utils.matchesTrigger(fenced));
+
+    const tildeFenced = '~~~\n@netlify run\n~~~';
+    assert.ok(!utils.matchesTrigger(tildeFenced));
+  });
+
+  it('still matches when an unbacticked @netlify appears alongside quoted ones', () => {
+    assert.ok(utils.matchesTrigger('the `@netlify` mention is what fires; please @netlify do the thing'));
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Constrain which content the action treats as durable state so a non-bot comment or fork PR body cannot inject `runner-id` / `session-data` values that a later authorized trigger would consume.

The trigger gate (`check-trigger.js`) already verifies *who fires* the `@netlify` event. It does not gate *whose comment / PR-body content the action treats as state*. This PR closes that asymmetry.

## What changed

- **`find-comment` author filter.** Both calls in `action.yml` now pass `comment-author` (resolved at runtime from `users.getAuthenticated`) and `direction: last`. Only bot-authored status / history comments contribute to state recovery.
- **PR-body fallback restricted to same-repo PRs.** `extract-agent-id.js` checks `head.repo.full_name === base.repo.full_name`; fork PR bodies are logged and skipped.
- **`createAgentRunnerSession` payload built with `jq --arg`** instead of bash string concatenation, so `agent_runner_id` / prompt / agent values can no longer smuggle additional JSON keys.
- **`parseRunnerId` format validation.** Rejects ids containing JSON-breaking characters, whitespace, newlines, or longer than 128 chars.
- **Session-data URL allowlist.** `parseSessionData` drops `pr_url` / `gh_action_url` / `screenshot` fields that don't match strict patterns (github.com pull / action paths, netlify-owned hosts). `commit_sha` must be 4–64 hex.
- **Two complementary HTML-comment scrubbers in `comment-markers.js`:**
  - `stripUntrustedHtmlComments` (read path) — keeps our markers, drops everything else. Wired into `extract-agent-id.js`.
  - `stripAllHtmlComments` (write path) — removes every HTML comment unconditionally. Wired into `formatPromptBlock` so user-authored prompts cannot reflect marker-shaped strings into bot-authored comment bodies.

## Compatibility

- The bot-identity step uses `inputs.github-token`. With the default `secrets.GITHUB_TOKEN`, identity resolves to `github-actions[bot]`. With a GitHub App or PAT, it resolves to that account — which is exactly the identity that posts status updates, so existing in-flight state remains readable.
- Lookup failure falls back to `github-actions[bot]` with a warning.
- Existing `runner_abc123` / `runner-pr-555` style ids in fixtures still pass the new format check.
- No public action input/output contracts changed.

## Test plan

- [x] Existing suite green (`npm test` — 221 / 221).
- [x] `npm run typecheck` clean.
- [x] New unit tests cover: author-filter behavior, fork-PR fallback rejection, runner-id format validation, session-data URL allowlisting, both strip helpers.
- [ ] Canary workflow (this PR triggers it) exercises the end-to-end happy path against a real Netlify agent run.
- [ ] Manual: comment `@netlify` on this PR after CI green to verify `find-comment` author filter and end-to-end bot identity resolution behave correctly under the default `github.token`.