### PR TITLE
fix: surface failed/cancelled session states as runner failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ next-env.d.ts
 
 # bv (beads viewer) local config and caches
 .bv/
+
+# ntm (multi-agent tmux orchestration) local state
+.ntm/

--- a/action.yml
+++ b/action.yml
@@ -933,7 +933,6 @@ runs:
           case "$STATE" in
             completed|done)
               echo "✅ Agent completed"
-              echo "outcome=success" >> $GITHUB_OUTPUT
 
               # Fetch session details
               SESSION_OUTPUT=$(netlify api listAgentRunnerSessions --data "{\"agent_runner_id\": \"$AGENT_ID\"}" 2>/dev/null || true)
@@ -953,6 +952,19 @@ runs:
               else
                 LATEST_SESSION='{}'
               fi
+
+              LATEST_SESSION_STATE=$(echo "$LATEST_SESSION" | jq -r '.state // empty' | tr '[:upper:]' '[:lower:]')
+              case "$LATEST_SESSION_STATE" in
+                failed|error|cancelled|canceled)
+                  echo "❌ Latest agent session finished with state: $LATEST_SESSION_STATE"
+                  LATEST_SESSION_ERROR=$(echo "$LATEST_SESSION" | jq -r '.error_message // .error // .result // empty')
+                  echo "outcome=failure" >> $GITHUB_OUTPUT
+                  emit_failure_context "poll-session" "agent-failed" "${LATEST_SESSION_ERROR:-Latest agent session finished with state: $LATEST_SESSION_STATE}"
+                  exit 1
+                  ;;
+              esac
+
+              echo "outcome=success" >> $GITHUB_OUTPUT
 
               # Re-fetch runner
               AGENT_RESULT=$(netlify agents:show "$AGENT_ID" --json 2>/dev/null || true)

--- a/src/action-wiring.test.js
+++ b/src/action-wiring.test.js
@@ -210,6 +210,12 @@ describe('action.yml wiring', () => {
     assert.match(actionYml, /Latest follow-up session produced no deploy\/code artifacts; reusing existing PR without a new commit/);
   });
 
+  it('fails completed runners when the latest session failed', () => {
+    assert.match(actionYml, /LATEST_SESSION_STATE=\$\(echo "\$LATEST_SESSION" \| jq -r '.state \/\/ empty'/);
+    assert.match(actionYml, /failed\|error\|cancelled\|canceled\)/);
+    assert.match(actionYml, /emit_failure_context "poll-session" "agent-failed"/);
+  });
+
   it('generates rich error comments even after the agent step fails', () => {
     const errorCommentBlock = extractStepBlocks(actionYml)
       .find(block => block.includes('- name: Generate error comment'));

--- a/src/generate-result-comment.js
+++ b/src/generate-result-comment.js
@@ -137,7 +137,10 @@ function renderResultComment({ env = process.env, context, outcome }) {
 
   const siteName = env.SITE_NAME || context.repo.repo;
   const agentRunUrl = `https://app.netlify.com/projects/${siteName}/agent-runs/${agentId}`;
-  const isFailure = outcome ? outcome === 'failure' : Boolean(env.AGENT_ERROR);
+  const latestSessionState = String(latestSession.state || '').toLowerCase();
+  const isFailure = outcome
+    ? outcome === 'failure'
+    : Boolean(env.AGENT_ERROR) || ['failed', 'error', 'cancelled', 'canceled'].includes(latestSessionState);
   const model = (latestSession.agent_config && latestSession.agent_config.agent) || env.AGENT_MODEL || 'codex';
   const runNumber = sessions.length;
   const timestamp = new Date().toISOString();
@@ -173,7 +176,9 @@ function renderResultComment({ env = process.env, context, outcome }) {
       for (const step of failure.remediation) body += `- ${cleanProse(step)}\n`;
       body += '\n';
     }
-    const errorText = truncateErrorText(cleanProse(env.AGENT_ERROR || '').replace(/```/g, "'''"));
+    const errorText = truncateErrorText(
+      cleanProse(env.AGENT_ERROR || latestSession.error_message || latestSession.error || latestSession.result || '').replace(/```/g, "'''")
+    );
     if (errorText) body += `**Error excerpt:**\n\n\`\`\`text\n${errorText}\n\`\`\`\n\n`;
   } else {
     body += title ? `### Result: ${title}\n\n` : '### Result\n\n';

--- a/src/generate-result-comment.test.js
+++ b/src/generate-result-comment.test.js
@@ -128,6 +128,32 @@ describe('renderResultComment', () => {
     assert.ok(rendered.resultBody.includes(RESULT_COMMENT_MARKER_PREFIX));
   });
 
+  it('treats latest error sessions as failure results even without AGENT_ERROR', () => {
+    writeSessions('runner_5', [{
+      id: 'session_5',
+      state: 'error',
+      prompt: '@netlify try again',
+      title: 'Cross-score ideas',
+      result: 'Encountered a temporary issue — the agent will attempt to continue.',
+      agent_config: { agent: 'claude' },
+    }]);
+
+    const rendered = renderResultComment({
+      context: context(),
+      env: {
+        RUNNER_TEMP: tempDir,
+        AGENT_ID: 'runner_5',
+        SITE_NAME: 'site',
+        SESSION_DATA_MAP: '{}',
+      },
+    });
+
+    assert.ok(rendered.resultBody.includes('### [Run #1 | claude | Agent Run failed]'));
+    assert.ok(rendered.resultBody.includes('**Error excerpt:**'));
+    assert.ok(rendered.resultBody.includes('Encountered a temporary issue'));
+    assert.ok(rendered.resultBody.includes(RESULT_COMMENT_MARKER_PREFIX));
+  });
+
   it('emits no result body when there is no latest session id', () => {
     const rendered = renderResultComment({
       context: context(),


### PR DESCRIPTION
## Summary
- `action.yml` now inspects the latest session after `listAgentRunnerSessions`. If its state is `failed`, `error`, `cancelled`, or `canceled`, the step sets `outcome=failure`, calls `emit_failure_context "poll-session" "agent-failed"`, and exits non-zero — previously a completed runner with a failed last session was still treated as a success.
- `src/generate-result-comment.js` renders the failed result comment when `latestSession.state` is an error state, even if `AGENT_ERROR` is empty, and falls back to `error_message` / `error` / `result` for the error excerpt.
- Adds regression coverage in `src/action-wiring.test.js` and `src/generate-result-comment.test.js`.

## Test plan
- [ ] `npm test`
- [ ] Trigger a runner whose latest session ends in `error` / `cancelled` and confirm the workflow fails and the PR comment renders as failed