### PR TITLE
Add usage metadata to result markers

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -139,6 +139,12 @@ runs:
           const run = require(`${process.env.ACTION_DIR}/src/check-trigger.js`);
           await run({ github, context, core });
 
+    - name: Install action dependencies
+      if: steps.trigger-check.outputs.should-run == 'true'
+      shell: bash
+      working-directory: ${{ github.action_path }}
+      run: npm ci --omit=dev --ignore-scripts --no-audit --no-fund
+
     # -----------------------------------------------------------------------
     # 2. React with 👀 to acknowledge
     # -----------------------------------------------------------------------

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "agent-runner-repo",
       "version": "1.0.0",
       "license": "ISC",
+      "dependencies": {
+        "comment-block-parser": "^1.5.4"
+      },
       "devDependencies": {
         "@types/node": "^25.5.0",
         "typescript": "^6.0.2"
@@ -21,6 +24,61 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/comment-block-parser": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/comment-block-parser/-/comment-block-parser-1.5.4.tgz",
+      "integrity": "sha512-GNE9VPctaq5HDkD7lKiLvkUq+mn2NMpOS9/IxA7oDVOPaIAqN6363giJD5D12Wnp1eCZyw7amTTR2pv7iZRbWw==",
+      "license": "MIT",
+      "dependencies": {
+        "dedent": "^1.6.0",
+        "mri": "^1.2.0",
+        "oparser": "^3.0.24"
+      },
+      "bin": {
+        "comment-block-parser": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/dedent": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/json-alexander": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/json-alexander/-/json-alexander-0.1.13.tgz",
+      "integrity": "sha512-s84SuqZwnb7mGJB03sGlcdx458FR91Uwwy2lKJBDN+TBJ7ARbyP/ssGnjW9t5QyxwG/b23W22Dz9Ga6nuyHqnA==",
+      "license": "MIT"
+    },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/oparser": {
+      "version": "3.0.24",
+      "resolved": "https://registry.npmjs.org/oparser/-/oparser-3.0.24.tgz",
+      "integrity": "sha512-dBeR+X0BTWn2JI/7/YSuUxQOPOnHcNxd0ViBaoHQQLkYzkLqzYBaLraa2i7IK2hjg7Xc3rwCZNdZUucJjBuUgg==",
+      "license": "MIT",
+      "dependencies": {
+        "json-alexander": "^0.1.13"
       }
     },
     "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
   "devDependencies": {
     "@types/node": "^25.5.0",
     "typescript": "^6.0.2"
+  },
+  "dependencies": {
+    "comment-block-parser": "^1.5.4"
   }
 }

--- a/src/comment-markers.js
+++ b/src/comment-markers.js
@@ -5,6 +5,7 @@ const HISTORY_COMMENT_MARKER = '<!-- netlify-agent-run-history -->';
 const RUNNER_ID_MARKER_PREFIX = '<!-- netlify-agent-runner-id:';
 const SESSION_DATA_MARKER_PREFIX = '<!-- netlify-agent-session-data:';
 const RESULT_COMMENT_MARKER_PREFIX = '<!-- netlify-agent-run-result:';
+const RESULT_COMMENT_MARKER_NAME = 'netlify-agent-run-result';
 const MARKER_SUFFIX = '-->';
 
 // Conservative format for runner IDs: alphanumerics, underscore, hyphen only.
@@ -16,7 +17,7 @@ const RUNNER_ID_FORMAT = /^[A-Za-z0-9_-]{1,128}$/;
 // found in user-influenced content is stripped before parsing/rendering, so
 // outsiders cannot smuggle fake markers and bot comments cannot accidentally
 // reflect attacker-supplied markers from echoed user content.
-const ALLOWED_MARKER_INNER = /^\s*netlify-agent-(?:run-status|run-history|run-result:|runner-id:|session-data:)/;
+const ALLOWED_MARKER_INNER = /^\s*netlify-agent-(?:run-status|run-history|run-result(?::|\s|$)|runner-id:|session-data:)/;
 
 // Allowlist for URL-bearing fields in session-data entries. These URLs flow
 // into bot-rendered Markdown links; anything outside these patterns gets
@@ -95,6 +96,63 @@ function renderMarker(markerWithValue) {
 }
 
 /**
+ * @param {string} value
+ * @returns {string}
+ */
+function quoteAttribute(value) {
+  return JSON.stringify(String(value));
+}
+
+/**
+ * @param {unknown} value
+ * @returns {number | null}
+ */
+function finiteNumber(value) {
+  const number = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(number) && number >= 0 ? number : null;
+}
+
+/**
+ * @param {unknown} usage
+ * @returns {{totalTokens?: number, totalCreditsCost?: number, stepsCount?: number, creditLimitExceeded?: boolean} | null}
+ */
+function normalizeResultUsage(usage) {
+  if (!usage || typeof usage !== 'object' || Array.isArray(usage)) return null;
+  const record = /** @type {Record<string, unknown>} */ (usage);
+  /** @type {{totalTokens?: number, totalCreditsCost?: number, stepsCount?: number, creditLimitExceeded?: boolean}} */
+  const out = {};
+
+  const totalTokens = finiteNumber(record.totalTokens ?? record.total_tokens);
+  if (totalTokens !== null) out.totalTokens = totalTokens;
+
+  const totalCreditsCost = finiteNumber(record.totalCreditsCost ?? record.total_credits_cost);
+  if (totalCreditsCost !== null) out.totalCreditsCost = totalCreditsCost;
+
+  const stepsCount = finiteNumber(record.stepsCount ?? record.steps_count);
+  if (stepsCount !== null) out.stepsCount = Math.floor(stepsCount);
+
+  if (typeof record.creditLimitExceeded === 'boolean') {
+    out.creditLimitExceeded = record.creditLimitExceeded;
+  } else if (typeof record.credit_limit_exceeded === 'boolean') {
+    out.creditLimitExceeded = record.credit_limit_exceeded;
+  }
+
+  return Object.keys(out).length > 0 ? out : null;
+}
+
+/**
+ * Load the parser only on the read path that needs it. This keeps early
+ * trigger checks working before the composite action installs dependencies.
+ * @param {string} content
+ * @param {Record<string, unknown>} options
+ * @returns {{blocks?: Array<Record<string, any>>}}
+ */
+function parseCommentBlocks(content, options) {
+  const { parseBlocks } = require('comment-block-parser');
+  return /** @type {{blocks?: Array<Record<string, any>>}} */ (parseBlocks(content, options));
+}
+
+/**
  * @param {unknown} body
  * @param {string} markerPrefix
  * @returns {string}
@@ -137,21 +195,63 @@ function parseRunnerId(body) {
 }
 
 /**
- * @param {{runnerId?: string, sessionId?: string}} identifiers
+ * @param {{runnerId?: string, sessionId?: string, usage?: Record<string, unknown> | null}} identifiers
  * @returns {string}
  */
-function renderResultCommentMarker({ runnerId = '', sessionId = '' } = {}) {
+function renderResultCommentMarker({ runnerId = '', sessionId = '', usage = null } = {}) {
   if (!RUNNER_ID_FORMAT.test(runnerId) || !RUNNER_ID_FORMAT.test(sessionId)) {
     return '';
   }
-  return renderMarker(`${RESULT_COMMENT_MARKER_PREFIX}${runnerId}:${sessionId}`);
+  const normalizedUsage = normalizeResultUsage(usage);
+  const attributes = [
+    `runnerId=${quoteAttribute(runnerId)}`,
+    `sessionId=${quoteAttribute(sessionId)}`,
+  ];
+  if (normalizedUsage && normalizedUsage.totalTokens !== undefined) {
+    attributes.push(`totalTokens=${normalizedUsage.totalTokens}`);
+  }
+  if (normalizedUsage && normalizedUsage.totalCreditsCost !== undefined) {
+    attributes.push(`totalCreditsCost=${normalizedUsage.totalCreditsCost}`);
+  }
+  if (normalizedUsage && normalizedUsage.stepsCount !== undefined) {
+    attributes.push(`stepsCount=${normalizedUsage.stepsCount}`);
+  }
+  if (normalizedUsage && normalizedUsage.creditLimitExceeded !== undefined) {
+    attributes.push(`creditLimitExceeded=${normalizedUsage.creditLimitExceeded ? 'true' : 'false'}`);
+  }
+  return renderMarker(`<!-- ${RESULT_COMMENT_MARKER_NAME} ${attributes.join(' ')}`);
 }
 
 /**
  * @param {unknown} body
- * @returns {{runnerId: string, sessionId: string} | null}
+ * @returns {{runnerId: string, sessionId: string, usage: {totalTokens?: number, totalCreditsCost?: number, stepsCount?: number, creditLimitExceeded?: boolean} | null} | null}
  */
-function parseResultCommentIdentifiers(body) {
+function parseResultCommentMarker(body) {
+  const text = normalizeBody(body);
+  if (!text) return null;
+
+  const parsed = parseCommentBlocks(text, {
+    syntax: 'md',
+    open: RESULT_COMMENT_MARKER_NAME,
+    close: false,
+  });
+  const block = parsed.blocks && parsed.blocks[0];
+  const options = block && block.options && typeof block.options === 'object'
+    ? /** @type {Record<string, unknown>} */ (block.options)
+    : null;
+  if (options && (options.runnerId !== undefined || options.sessionId !== undefined)) {
+    const runnerId = typeof options.runnerId === 'string' ? options.runnerId : '';
+    const sessionId = typeof options.sessionId === 'string' ? options.sessionId : '';
+    if (!RUNNER_ID_FORMAT.test(runnerId) || !RUNNER_ID_FORMAT.test(sessionId)) {
+      return null;
+    }
+    return {
+      runnerId,
+      sessionId,
+      usage: normalizeResultUsage(options),
+    };
+  }
+
   const value = readMarkerValue(body, RESULT_COMMENT_MARKER_PREFIX);
   if (!value) return null;
 
@@ -161,7 +261,17 @@ function parseResultCommentIdentifiers(body) {
   if (!RUNNER_ID_FORMAT.test(runnerId) || !RUNNER_ID_FORMAT.test(sessionId)) {
     return null;
   }
-  return { runnerId, sessionId };
+  return { runnerId, sessionId, usage: null };
+}
+
+/**
+ * @param {unknown} body
+ * @returns {{runnerId: string, sessionId: string} | null}
+ */
+function parseResultCommentIdentifiers(body) {
+  const parsed = parseResultCommentMarker(body);
+  if (!parsed) return null;
+  return { runnerId: parsed.runnerId, sessionId: parsed.sessionId };
 }
 
 /**
@@ -300,10 +410,13 @@ module.exports = {
   RUNNER_ID_MARKER_PREFIX,
   SESSION_DATA_MARKER_PREFIX,
   RESULT_COMMENT_MARKER_PREFIX,
+  RESULT_COMMENT_MARKER_NAME,
   RUNNER_ID_FORMAT,
+  normalizeResultUsage,
   renderRunnerIdMarker,
   parseRunnerId,
   renderResultCommentMarker,
+  parseResultCommentMarker,
   parseResultCommentIdentifiers,
   renderSessionDataMarker,
   parseSessionData,

--- a/src/comment-markers.js
+++ b/src/comment-markers.js
@@ -27,7 +27,7 @@ const SESSION_URL_ALLOWLIST = {
   gh_action_url: /^https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/actions\/runs\/\d+(?:[/?#].*)?$/,
   screenshot:    /^https:\/\/(?:[A-Za-z0-9-]+\.)*(?:netlify\.app|netlifyusercontent\.com|app\.netlify\.com|api\.netlify\.com)\/[^\s]*$/i,
 };
-const AGENT_RUN_URL_PATTERN = /https:\/\/app\.netlify\.com\/projects\/([A-Za-z0-9_.-]+)\/agent-runs\/([A-Za-z0-9_-]{1,128})(?=$|[\s)\]>}.,!?])/g;
+const AGENT_RUN_URL_PATTERN = /https:\/\/app\.netlify\.com\/projects\/([A-Za-z0-9_.-]+)\/agent-runs\/([A-Za-z0-9_-]{1,128})(?:\?session=([A-Za-z0-9_-]{1,128}))?(?=$|[\s)\]>}.,!?])/g;
 // 4 covers git's minimum unique-prefix display; 64 covers full SHA-256.
 const COMMIT_SHA_FORMAT = /^[0-9a-f]{4,64}$/i;
 const SESSION_FIELD_MAX_LENGTH = 2048;
@@ -138,6 +138,19 @@ function normalizeResultUsage(usage) {
   }
 
   return Object.keys(out).length > 0 ? out : null;
+}
+
+/**
+ * @param {string} siteName
+ * @param {string} runnerId
+ * @param {string} [sessionId]
+ * @returns {string}
+ */
+function formatAgentRunUrl(siteName, runnerId, sessionId = '') {
+  if (!siteName || !RUNNER_ID_FORMAT.test(runnerId)) return '';
+  const base = `https://app.netlify.com/projects/${siteName}/agent-runs/${runnerId}`;
+  if (!RUNNER_ID_FORMAT.test(sessionId)) return base;
+  return `${base}?session=${encodeURIComponent(sessionId)}`;
 }
 
 /**
@@ -364,7 +377,7 @@ function parseAgentRunReference(body) {
     if (!RUNNER_ID_FORMAT.test(runnerId)) continue;
     return {
       runnerId,
-      agentRunUrl: `https://app.netlify.com/projects/${siteName}/agent-runs/${runnerId}`,
+      agentRunUrl: formatAgentRunUrl(siteName, runnerId),
     };
   }
 
@@ -413,6 +426,7 @@ module.exports = {
   RESULT_COMMENT_MARKER_NAME,
   RUNNER_ID_FORMAT,
   normalizeResultUsage,
+  formatAgentRunUrl,
   renderRunnerIdMarker,
   parseRunnerId,
   renderResultCommentMarker,

--- a/src/comment-markers.test.js
+++ b/src/comment-markers.test.js
@@ -34,7 +34,23 @@ describe('render helpers', () => {
   it('renders result comment markers when ids are valid', () => {
     assert.equal(
       markers.renderResultCommentMarker({ runnerId: 'runner_123', sessionId: 'session-456' }),
-      '<!-- netlify-agent-run-result:runner_123:session-456 -->'
+      '<!-- netlify-agent-run-result runnerId="runner_123" sessionId="session-456" -->'
+    );
+  });
+
+  it('renders compact usage attributes on result comment markers', () => {
+    assert.equal(
+      markers.renderResultCommentMarker({
+        runnerId: 'runner_123',
+        sessionId: 'session-456',
+        usage: {
+          total_tokens: 661381,
+          total_credits_cost: 145.98018,
+          steps_count: 46,
+          credit_limit_exceeded: false,
+        },
+      }),
+      '<!-- netlify-agent-run-result runnerId="runner_123" sessionId="session-456" totalTokens=661381 totalCreditsCost=145.98018 stepsCount=46 creditLimitExceeded=false -->'
     );
   });
 
@@ -163,8 +179,35 @@ describe('parseResultCommentIdentifiers', () => {
   it('extracts validated runner and session ids', () => {
     const body = [
       '### Result',
-      '<!-- netlify-agent-run-result:runner_123:session-456 -->',
+      '<!-- netlify-agent-run-result runnerId="runner_123" sessionId="session-456" -->',
     ].join('\n');
+    assert.deepEqual(markers.parseResultCommentIdentifiers(body), {
+      runnerId: 'runner_123',
+      sessionId: 'session-456',
+    });
+  });
+
+  it('parses compact usage attributes from result comment markers', () => {
+    const body = '<!-- netlify-agent-run-result runnerId="runner_123" sessionId="session-456" totalTokens=661381 totalCreditsCost=145.98018 stepsCount=46 creditLimitExceeded=false -->';
+    assert.deepEqual(markers.parseResultCommentMarker(body), {
+      runnerId: 'runner_123',
+      sessionId: 'session-456',
+      usage: {
+        totalTokens: 661381,
+        totalCreditsCost: 145.98018,
+        stepsCount: 46,
+        creditLimitExceeded: false,
+      },
+    });
+  });
+
+  it('keeps parsing legacy colon result markers', () => {
+    const body = '<!-- netlify-agent-run-result:runner_123:session-456 -->';
+    assert.deepEqual(markers.parseResultCommentMarker(body), {
+      runnerId: 'runner_123',
+      sessionId: 'session-456',
+      usage: null,
+    });
     assert.deepEqual(markers.parseResultCommentIdentifiers(body), {
       runnerId: 'runner_123',
       sessionId: 'session-456',
@@ -186,13 +229,13 @@ describe('stripUntrustedHtmlComments', () => {
       '<!-- something else -->',
       '<!-- netlify-agent-run-status -->',
       '<!-- netlify-agent-runner-id:abc -->',
-      '<!-- netlify-agent-run-result:runner:session -->',
+      '<!-- netlify-agent-run-result runnerId="runner" sessionId="session" -->',
       '<!-- evil -->',
     ].join('\n');
     const out = markers.stripUntrustedHtmlComments(input);
     assert.ok(out.includes('<!-- netlify-agent-run-status -->'));
     assert.ok(out.includes('<!-- netlify-agent-runner-id:abc -->'));
-    assert.ok(out.includes('<!-- netlify-agent-run-result:runner:session -->'));
+    assert.ok(out.includes('<!-- netlify-agent-run-result runnerId="runner" sessionId="session" -->'));
     assert.ok(!out.includes('something else'));
     assert.ok(!out.includes('evil'));
   });

--- a/src/comment-markers.test.js
+++ b/src/comment-markers.test.js
@@ -291,6 +291,17 @@ describe('parseLinkedPrReference', () => {
 });
 
 describe('parseAgentRunReference', () => {
+  it('formats session-specific Netlify agent run URLs', () => {
+    assert.equal(
+      markers.formatAgentRunUrl('site-a', 'runner_123', 'session-456'),
+      'https://app.netlify.com/projects/site-a/agent-runs/runner_123?session=session-456'
+    );
+    assert.equal(
+      markers.formatAgentRunUrl('site-a', 'runner_123', 'bad/session'),
+      'https://app.netlify.com/projects/site-a/agent-runs/runner_123'
+    );
+  });
+
   it('extracts bare Netlify agent run URLs from out-of-band PR bodies', () => {
     assert.deepEqual(
       markers.parseAgentRunReference('🔗 **View agent run:** https://app.netlify.com/projects/gmail-emailer/agent-runs/6a0bd975b0decdb25b6b3a23'),
@@ -304,6 +315,16 @@ describe('parseAgentRunReference', () => {
   it('extracts markdown-linked Netlify agent run URLs', () => {
     assert.deepEqual(
       markers.parseAgentRunReference('[Agent run](https://app.netlify.com/projects/site-a/agent-runs/runner_123)'),
+      {
+        runnerId: 'runner_123',
+        agentRunUrl: 'https://app.netlify.com/projects/site-a/agent-runs/runner_123',
+      }
+    );
+  });
+
+  it('extracts runner references from session-specific Netlify agent run URLs', () => {
+    assert.deepEqual(
+      markers.parseAgentRunReference('[Agent run](https://app.netlify.com/projects/site-a/agent-runs/runner_123?session=session-456)'),
       {
         runnerId: 'runner_123',
         agentRunUrl: 'https://app.netlify.com/projects/site-a/agent-runs/runner_123',

--- a/src/generate-result-comment.js
+++ b/src/generate-result-comment.js
@@ -6,6 +6,7 @@ const utils = require('./utils');
 const { classifyFailure } = require('./failure-taxonomy');
 const {
   renderResultCommentMarker,
+  normalizeResultUsage,
   assertNoStateMarkers,
   stripAllHtmlComments,
 } = require('./comment-markers');
@@ -86,6 +87,50 @@ function buildSessionDataMap(env, sessions) {
 }
 
 /**
+ * @param {Record<string, any> | null} latestSession
+ * @returns {{totalTokens?: number, totalCreditsCost?: number, stepsCount?: number, creditLimitExceeded?: boolean} | null}
+ */
+function usageFromSession(latestSession) {
+  if (!latestSession || typeof latestSession !== 'object') return null;
+  return normalizeResultUsage({
+    ...(latestSession.usage && typeof latestSession.usage === 'object' ? latestSession.usage : {}),
+    steps_count: latestSession.steps_count,
+    credit_limit_exceeded: latestSession.credit_limit_exceeded,
+  });
+}
+
+/**
+ * @param {number} value
+ * @returns {string}
+ */
+function numberWithCommas(value) {
+  return Number.isFinite(value) ? Math.round(value).toLocaleString('en-US') : '';
+}
+
+/**
+ * @param {number} value
+ * @returns {string}
+ */
+function formatCredits(value) {
+  if (!Number.isFinite(value)) return '';
+  return value.toFixed(2).replace(/\.?0+$/, '');
+}
+
+/**
+ * @param {{totalTokens?: number, totalCreditsCost?: number, stepsCount?: number, creditLimitExceeded?: boolean} | null} usage
+ * @returns {string}
+ */
+function formatUsageSummary(usage) {
+  if (!usage) return '';
+  const parts = [];
+  if (usage.totalTokens !== undefined) parts.push(`${numberWithCommas(usage.totalTokens)} tokens`);
+  if (usage.stepsCount !== undefined) parts.push(`${numberWithCommas(usage.stepsCount)} steps`);
+  if (usage.totalCreditsCost !== undefined) parts.push(`${formatCredits(usage.totalCreditsCost)} credits`);
+  if (usage.creditLimitExceeded) parts.push('credit limit exceeded');
+  return parts.join(' · ');
+}
+
+/**
  * @param {Record<string, string | undefined>} env
  * @param {import('./types').ActionContext} context
  * @param {Record<string, any>} latestSession
@@ -129,7 +174,9 @@ function renderResultComment({ env = process.env, context, outcome }) {
   const sessions = readSessions(agentId, env.RUNNER_TEMP);
   const latestSession = sessions.length > 0 ? sessions[sessions.length - 1] : null;
   const sessionId = latestSession && latestSession.id ? String(latestSession.id) : '';
-  const resultMarker = renderResultCommentMarker({ runnerId: agentId, sessionId });
+  const usage = usageFromSession(latestSession);
+  const usageSummary = formatUsageSummary(usage);
+  const resultMarker = renderResultCommentMarker({ runnerId: agentId, sessionId, usage });
   const sessionDataMap = buildSessionDataMap(env, sessions);
 
   if (!resultMarker || !latestSession) {
@@ -157,6 +204,7 @@ function renderResultComment({ env = process.env, context, outcome }) {
   const statusIcon = isFailure ? '❌' : '✅';
 
   let body = `### [Run #${runNumber} | ${model} | Agent Run ${isFailure ? 'failed' : 'completed'}](${agentRunUrl}) ${statusIcon}\n\n`;
+  if (usageSummary) body += `**Usage:** ${usageSummary}\n\n`;
   if (cleanPrompt) body += utils.formatPromptBlock(cleanPrompt, sourceUrl);
 
   if (isFailure) {
@@ -214,3 +262,5 @@ module.exports = async function generateResultComment({ context, core }) {
 module.exports.renderResultComment = renderResultComment;
 module.exports.cleanProse = cleanProse;
 module.exports.readSessions = readSessions;
+module.exports.usageFromSession = usageFromSession;
+module.exports.formatUsageSummary = formatUsageSummary;

--- a/src/generate-result-comment.js
+++ b/src/generate-result-comment.js
@@ -7,6 +7,7 @@ const { classifyFailure } = require('./failure-taxonomy');
 const {
   renderResultCommentMarker,
   normalizeResultUsage,
+  formatAgentRunUrl,
   assertNoStateMarkers,
   stripAllHtmlComments,
 } = require('./comment-markers');
@@ -141,7 +142,8 @@ function buildLinks(env, context, latestSession, sessions) {
   const repoName = env.REPOSITORY_NAME || `${context.repo.owner}/${context.repo.repo}`;
   const agentId = env.AGENT_ID || '';
   const siteName = env.SITE_NAME || context.repo.repo;
-  const agentRunUrl = agentId ? `https://app.netlify.com/projects/${siteName}/agent-runs/${agentId}` : '';
+  const sessionId = latestSession && latestSession.id ? String(latestSession.id) : '';
+  const agentRunUrl = formatAgentRunUrl(siteName, agentId, sessionId);
   const deployUrl = env.AGENT_DEPLOY_URL || latestSession.deploy_url || '';
   const commitSha = env.AGENT_COMMIT_SHA || '';
   const prUrl = env.AGENT_PR_URL || '';
@@ -184,7 +186,7 @@ function renderResultComment({ env = process.env, context, outcome }) {
   }
 
   const siteName = env.SITE_NAME || context.repo.repo;
-  const agentRunUrl = `https://app.netlify.com/projects/${siteName}/agent-runs/${agentId}`;
+  const agentRunUrl = formatAgentRunUrl(siteName, agentId, sessionId);
   const latestSessionState = String(latestSession.state || '').toLowerCase();
   const isFailure = outcome
     ? outcome === 'failure'

--- a/src/generate-result-comment.test.js
+++ b/src/generate-result-comment.test.js
@@ -5,7 +5,7 @@ const os = require('node:os');
 const path = require('node:path');
 const { renderResultComment } = require('./generate-result-comment');
 const {
-  RESULT_COMMENT_MARKER_PREFIX,
+  RESULT_COMMENT_MARKER_NAME,
   STATUS_COMMENT_MARKER,
   HISTORY_COMMENT_MARKER,
   RUNNER_ID_MARKER_PREFIX,
@@ -44,6 +44,12 @@ describe('renderResultComment', () => {
       result: 'Made the requested changes.',
       deploy_url: 'https://site.netlify.app',
       agent_config: { agent: 'codex' },
+      usage: {
+        total_tokens: 661381,
+        total_credits_cost: 145.98018,
+      },
+      steps_count: 46,
+      credit_limit_exceeded: false,
     }]);
 
     const rendered = renderResultComment({
@@ -62,11 +68,12 @@ describe('renderResultComment', () => {
     });
 
     assert.ok(rendered.resultBody.includes('### [Run #1 | codex | Agent Run completed]'));
+    assert.ok(rendered.resultBody.includes('**Usage:** 661,381 tokens · 46 steps · 145.98 credits'));
     assert.ok(rendered.resultBody.includes('**Prompt:**'));
     assert.ok(rendered.resultBody.includes('### Result: Updated homepage'));
     assert.ok(rendered.resultBody.includes('[Code Changes]'));
     assert.ok(rendered.resultBody.includes('[Pull Request](https://github.com/netlify-labs/agent-runner-action-example/pull/5)'));
-    assert.ok(rendered.resultBody.includes(RESULT_COMMENT_MARKER_PREFIX));
+    assert.ok(rendered.resultBody.includes('<!-- netlify-agent-run-result runnerId="runner_1" sessionId="session_1" totalTokens=661381 totalCreditsCost=145.98018 stepsCount=46 creditLimitExceeded=false -->'));
     assert.deepEqual(parseResultCommentIdentifiers(rendered.resultBody), {
       runnerId: 'runner_1',
       sessionId: 'session_1',
@@ -99,7 +106,7 @@ describe('renderResultComment', () => {
     assert.ok(!rendered.resultBody.includes(STATUS_COMMENT_MARKER));
     assert.ok(!rendered.resultBody.includes(RUNNER_ID_MARKER_PREFIX));
     assert.ok(!rendered.resultBody.includes(SESSION_DATA_MARKER_PREFIX));
-    assert.ok(rendered.resultBody.includes(RESULT_COMMENT_MARKER_PREFIX));
+    assert.ok(rendered.resultBody.includes(`<!-- ${RESULT_COMMENT_MARKER_NAME} `));
   });
 
   it('renders failure result comments when a latest session exists', () => {
@@ -126,7 +133,7 @@ describe('renderResultComment', () => {
 
     assert.ok(rendered.resultBody.includes('Agent Run failed'));
     assert.ok(rendered.resultBody.includes('Suggested next steps'));
-    assert.ok(rendered.resultBody.includes(RESULT_COMMENT_MARKER_PREFIX));
+    assert.ok(rendered.resultBody.includes(`<!-- ${RESULT_COMMENT_MARKER_NAME} `));
   });
 
   it('treats latest error sessions as failure results even without AGENT_ERROR', () => {
@@ -152,7 +159,7 @@ describe('renderResultComment', () => {
     assert.ok(rendered.resultBody.includes('### [Run #1 | claude | Agent Run failed]'));
     assert.ok(rendered.resultBody.includes('**Error excerpt:**'));
     assert.ok(rendered.resultBody.includes('Encountered a temporary issue'));
-    assert.ok(rendered.resultBody.includes(RESULT_COMMENT_MARKER_PREFIX));
+    assert.ok(rendered.resultBody.includes(`<!-- ${RESULT_COMMENT_MARKER_NAME} `));
   });
 
   it('emits no result body when there is no latest session id', () => {

--- a/src/generate-result-comment.test.js
+++ b/src/generate-result-comment.test.js
@@ -68,6 +68,7 @@ describe('renderResultComment', () => {
     });
 
     assert.ok(rendered.resultBody.includes('### [Run #1 | codex | Agent Run completed]'));
+    assert.ok(rendered.resultBody.includes('https://app.netlify.com/projects/site/agent-runs/runner_1?session=session_1'));
     assert.ok(rendered.resultBody.includes('**Usage:** 661,381 tokens · 46 steps · 145.98 credits'));
     assert.ok(rendered.resultBody.includes('**Prompt:**'));
     assert.ok(rendered.resultBody.includes('### Result: Updated homepage'));

--- a/src/generate-status-comment.js
+++ b/src/generate-status-comment.js
@@ -5,6 +5,7 @@ const utils = require('./utils');
 const { classifyFailure } = require('./failure-taxonomy');
 const {
   STATUS_COMMENT_MARKER,
+  formatAgentRunUrl,
   renderRunnerIdMarker,
   renderSessionDataMarker,
   stripAllHtmlComments,
@@ -74,7 +75,8 @@ function buildLinks(env, context, latestSession) {
   const repoName = env.REPOSITORY_NAME || `${context.repo.owner}/${context.repo.repo}`;
   const agentId = env.AGENT_ID || env.RUNNER_ID || '';
   const siteName = env.SITE_NAME || context.repo.repo;
-  const agentRunUrl = agentId ? `https://app.netlify.com/projects/${siteName}/agent-runs/${agentId}` : '';
+  const sessionId = latestSession && latestSession.id ? String(latestSession.id) : '';
+  const agentRunUrl = formatAgentRunUrl(siteName, agentId, sessionId);
   const deployUrl = env.AGENT_DEPLOY_URL || (latestSession && latestSession.deploy_url) || '';
   const ghActionUrl = env.GH_ACTION_URL || '';
   const commitSha = env.AGENT_COMMIT_SHA || '';
@@ -107,7 +109,8 @@ function renderStatusComment({ env = process.env, context, outcome }) {
   const latestSession = sessions.length > 0 ? sessions[sessions.length - 1] : null;
   const sessionDataMap = buildSessionDataMap(env, sessions);
   const siteName = env.SITE_NAME || context.repo.repo;
-  const agentRunUrl = agentId ? `https://app.netlify.com/projects/${siteName}/agent-runs/${agentId}` : '';
+  const sessionId = latestSession && latestSession.id ? String(latestSession.id) : '';
+  const agentRunUrl = formatAgentRunUrl(siteName, agentId, sessionId);
   const isFailure = outcome ? outcome === 'failure' : Boolean(env.AGENT_ERROR);
   const isDryRun = env.IS_DRY_RUN === 'true';
   const model = (latestSession && latestSession.agent_config && latestSession.agent_config.agent) || env.AGENT_MODEL || 'codex';

--- a/src/generate-status-comment.test.js
+++ b/src/generate-status-comment.test.js
@@ -54,7 +54,7 @@ describe('renderStatusComment', () => {
 
     const visible = rendered.statusBody.split('<!-- netlify-agent-session-data:')[0].trim();
     assert.ok(byteLength(visible) <= STATUS_COMMENT_VISIBLE_BYTES);
-    assert.ok(rendered.statusBody.includes('### [Netlify Agent Run Status](https://app.netlify.com/projects/site/agent-runs/runner_1) ✅'));
+    assert.ok(rendered.statusBody.includes('### [Netlify Agent Run Status](https://app.netlify.com/projects/site/agent-runs/runner_1?session=session_1) ✅'));
     assert.ok(rendered.statusBody.includes('Netlify Agent Run completed.'));
     assert.ok(rendered.statusBody.includes('**Prompt summary:** Updated homepage'));
     assert.ok(rendered.statusBody.includes('[Read full result](#issuecomment-123)'));
@@ -97,7 +97,7 @@ describe('renderStatusComment', () => {
         SESSION_DATA_MAP: '{}',
       },
     });
-    assert.ok(rendered.statusBody.includes('### [Netlify Agent Run Status](https://app.netlify.com/projects/site/agent-runs/runner_3) ❌'));
+    assert.ok(rendered.statusBody.includes('### [Netlify Agent Run Status](https://app.netlify.com/projects/site/agent-runs/runner_3?session=session_3) ❌'));
     assert.ok(rendered.statusBody.includes('Netlify Agent Run failed.'));
     assert.ok(rendered.statusBody.includes('**Failure summary:**'));
     assert.ok(rendered.statusBody.includes('[Read full result](#issuecomment-777)'));

--- a/src/scenario-harness.test.js
+++ b/src/scenario-harness.test.js
@@ -193,7 +193,7 @@ describe('scenario harness', () => {
 
     assert.equal(trace.outputs['is-pr'], 'true');
     assert.equal(trace.comments.length, 3);
-    assert.ok(trace.comments[0].includes('<!-- netlify-agent-run-result:runner-thread:session-thread -->'));
+    assert.ok(trace.comments[0].includes('<!-- netlify-agent-run-result runnerId="runner-thread" sessionId="session-thread"'));
     assert.ok(trace.comments[1].includes('<!-- netlify-agent-run-status -->'));
     assert.ok(trace.comments[1].includes('[Read full result]('));
     assert.ok(trace.comments[2].includes('<!-- netlify-agent-run-history -->'));
@@ -227,7 +227,7 @@ describe('scenario harness', () => {
         commentMode: 'success',
       });
 
-      const resultBody = trace.comments.find(comment => comment.includes('<!-- netlify-agent-run-result:'));
+      const resultBody = trace.comments.find(comment => comment.includes('<!-- netlify-agent-run-result '));
       assert.ok(resultBody, `expected run ${index} result comment`);
       historyComments.push({
         id,
@@ -284,7 +284,7 @@ describe('scenario harness', () => {
 
     assert.equal(trace.comments.length, 1);
     assert.ok(trace.comments[0].includes('<!-- netlify-agent-run-status -->'));
-    assert.ok(!trace.comments[0].includes('<!-- netlify-agent-run-result:'));
+    assert.ok(!trace.comments[0].includes('<!-- netlify-agent-run-result'));
   });
 
   it('keeps result-post failures status-only with no history TOC', async () => {


### PR DESCRIPTION
## Summary
- emit compact usage metadata on result comment markers using comment-block-parser attribute syntax
- show a short usage summary in immutable result comments
- keep legacy colon result marker parsing for older comments
- install action runtime dependencies after trigger detection for composite action consumers

## Validation
- bun test src/*.test.js
- bunx tsc --noEmit
- git diff --check

Canary should run on this PR because it touches action/source files.