### PR TITLE
fix(comments): escape attacker-controlled URLs and titles in comment HTML

### DIFF
--- a/src/generate-history-comment.js
+++ b/src/generate-history-comment.js
@@ -66,10 +66,12 @@ module.exports = async function generateHistoryComment({ context, core }) {
       if (ghUrl) message += `[GitHub Action logs](${ghUrl})\n\n`;
     } else {
       const title = session.title || '';
-      if (screenshot && deployUrl) {
-        message += `<a href="${deployUrl}"><img src="${screenshot}" alt="Preview" width="180" align="right"></a>`;
+      const safeDeployUrl = utils.safeHttpUrl(deployUrl);
+      const safeScreenshot = utils.safeHttpUrl(screenshot);
+      if (safeScreenshot && safeDeployUrl) {
+        message += `<a href="${utils.escapeAttr(safeDeployUrl)}"><img src="${utils.escapeAttr(safeScreenshot)}" alt="Preview" width="180" align="right"></a>`;
       }
-      message += `✅ \`${runHeader}\`\n\n${title}\n\n`;
+      message += `✅ \`${runHeader}\`\n\n${utils.escapeMarkdownLinks(title)}\n\n`;
       if (cleanPrompt) message += utils.formatPromptBlock(cleanPrompt, sourceUrl);
       const commitSha = data.commit_sha || '';
       const prUrl = data.pr_url || '';

--- a/src/generate-result-comment.js
+++ b/src/generate-result-comment.js
@@ -216,7 +216,7 @@ function renderResultComment({ env = process.env, context, outcome }) {
       error: env.AGENT_ERROR || '',
       statusCode: env.FAILURE_STATUS_CODE ? parseInt(env.FAILURE_STATUS_CODE, 10) : undefined,
     });
-    body += title ? `### Result: ${title}\n\n` : '### Result\n\n';
+    body += title ? `### Result: ${utils.escapeMarkdownLinks(title)}\n\n` : '### Result\n\n';
     body += `${failure.summary}\n\n`;
     body += `- **Category:** \`${failure.category}\`\n`;
     body += `- **Stage:** \`${failure.stage}\`\n`;
@@ -232,11 +232,13 @@ function renderResultComment({ env = process.env, context, outcome }) {
     );
     if (errorText) body += `**Error excerpt:**\n\n\`\`\`text\n${errorText}\n\`\`\`\n\n`;
   } else {
-    body += title ? `### Result: ${title}\n\n` : '### Result\n\n';
-    if (screenshotUrl && deployUrl) {
-      body += `<a href="${deployUrl}"><img src="${screenshotUrl}" alt="Preview" width="250" align="right"></a>\n\n`;
+    body += title ? `### Result: ${utils.escapeMarkdownLinks(title)}\n\n` : '### Result\n\n';
+    const safeDeployUrl = utils.safeHttpUrl(deployUrl);
+    const safeScreenshotUrl = utils.safeHttpUrl(screenshotUrl);
+    if (safeScreenshotUrl && safeDeployUrl) {
+      body += `<a href="${utils.escapeAttr(safeDeployUrl)}"><img src="${utils.escapeAttr(safeScreenshotUrl)}" alt="Preview" width="250" align="right"></a>\n\n`;
     }
-    if (resultSummary) body += `${resultSummary}\n\n`;
+    if (resultSummary) body += `${utils.escapeMarkdownLinks(resultSummary)}\n\n`;
   }
 
   if (links.length > 0) body += `${links.join(' | ')}\n\n`;

--- a/src/generate-status-comment.js
+++ b/src/generate-status-comment.js
@@ -132,13 +132,13 @@ function renderStatusComment({ env = process.env, context, outcome }) {
   const subtitle = statusLine;
   const runLine = `Run #${runNumber} | ${model} | ${isFailure ? 'failed' : 'completed'} at ${timestamp}`;
 
-  const deployUrl = env.AGENT_DEPLOY_URL || (latestSession && latestSession.deploy_url) || '';
-  const screenshotUrl = env.AGENT_SCREENSHOT_URL || '';
+  const deployUrl = utils.safeHttpUrl(env.AGENT_DEPLOY_URL || (latestSession && latestSession.deploy_url) || '');
+  const screenshotUrl = utils.safeHttpUrl(env.AGENT_SCREENSHOT_URL || '');
   const screenshot = screenshotUrl && deployUrl
-    ? `<a href="${deployUrl}"><img src="${screenshotUrl}" alt="Preview" width="180" align="right"></a>`
+    ? `<a href="${utils.escapeAttr(deployUrl)}"><img src="${utils.escapeAttr(screenshotUrl)}" alt="Preview" width="180" align="right"></a>`
     : '';
 
-  let statusTitle = title ? `${runLine}\n\n**Prompt summary:** ${title}` : runLine;
+  let statusTitle = title ? `${runLine}\n\n**Prompt summary:** ${utils.escapeMarkdownLinks(title)}` : runLine;
   if (isFailure) {
     const failure = classifyFailure({
       category: env.FAILURE_CATEGORY || env.AGENT_FAILURE_CATEGORY || '',

--- a/src/generate-success-comment.js
+++ b/src/generate-success-comment.js
@@ -80,13 +80,15 @@ module.exports = async function generateSuccessComment({ context, core }) {
   }
 
   if (cleanPrompt) message += utils.formatPromptBlock(cleanPrompt, sourceUrl);
-  message += agentTitle ? `### Result: ${agentTitle}\n\n` : `### Result\n\n`;
+  message += agentTitle ? `### Result: ${utils.escapeMarkdownLinks(agentTitle)}\n\n` : `### Result\n\n`;
 
-  if (agentScreenshotUrl && agentDeployUrl) {
-    message += `<a href="${agentDeployUrl}"><img src="${agentScreenshotUrl}" alt="Preview" width="250" align="right"></a>\n\n`;
+  const safeDeployUrl = utils.safeHttpUrl(agentDeployUrl);
+  const safeScreenshotUrl = utils.safeHttpUrl(agentScreenshotUrl);
+  if (safeScreenshotUrl && safeDeployUrl) {
+    message += `<a href="${utils.escapeAttr(safeDeployUrl)}"><img src="${utils.escapeAttr(safeScreenshotUrl)}" alt="Preview" width="250" align="right"></a>\n\n`;
   }
 
-  if (agentResultSummary.trim()) message += `${agentResultSummary.trim()}\n\n`;
+  if (agentResultSummary.trim()) message += `${utils.escapeMarkdownLinks(agentResultSummary.trim())}\n\n`;
 
   /** @type {string[]} */
   const links = [];

--- a/src/utils.js
+++ b/src/utils.js
@@ -124,8 +124,12 @@ function cleanPrompt(text) {
  * @returns {string}
  */
 function escapeAttr(value) {
-  return String(value || '').replace(/[&"<>]/g, c =>
-    ({ '&': '&amp;', '"': '&quot;', '<': '&lt;', '>': '&gt;' }[c]));
+  return String(value || '').replace(/[&"<>]/g, c => {
+    if (c === '&') return '&amp;';
+    if (c === '"') return '&quot;';
+    if (c === '<') return '&lt;';
+    return '&gt;';
+  });
 }
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -118,6 +118,38 @@ function cleanPrompt(text) {
 }
 
 /**
+ * Escape HTML attribute values to prevent attribute injection when splicing
+ * untrusted strings into raw `<a>` / `<img>` tags inside comment bodies.
+ * @param {string | null | undefined} value
+ * @returns {string}
+ */
+function escapeAttr(value) {
+  return String(value || '').replace(/[&"<>]/g, c =>
+    ({ '&': '&amp;', '"': '&quot;', '<': '&lt;', '>': '&gt;' }[c]));
+}
+
+/**
+ * Return `value` only if it parses as a plain http(s) URL with no embedded
+ * whitespace or quote characters, otherwise return empty string.
+ * @param {string | null | undefined} value
+ * @returns {string}
+ */
+function safeHttpUrl(value) {
+  const s = String(value || '').trim();
+  return /^https?:\/\/[^\s"'<>]+$/.test(s) ? s : '';
+}
+
+/**
+ * Escape `[` so attacker-controlled prose interpolated into markdown can't
+ * form a `[label](url)` link.
+ * @param {string | null | undefined} value
+ * @returns {string}
+ */
+function escapeMarkdownLinks(value) {
+  return String(value || '').replace(/\[/g, '\\[');
+}
+
+/**
  * Pick a random [flavorText, emoji] pair.
  * @returns {[string, string]}
  */
@@ -249,4 +281,7 @@ module.exports = {
   formatPromptBlock,
   formatRunDate,
   buildInProgressComment,
+  escapeAttr,
+  safeHttpUrl,
+  escapeMarkdownLinks,
 };

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -292,3 +292,56 @@ describe('TRIGGER_PATTERN', () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// escapeAttr / safeHttpUrl / escapeMarkdownLinks
+// ---------------------------------------------------------------------------
+describe('escapeAttr', () => {
+  it('escapes the four attribute-breaking characters', () => {
+    assert.equal(utils.escapeAttr('a"b<c>d&e'), 'a&quot;b&lt;c&gt;d&amp;e');
+  });
+
+  it('blocks the issue #16 attribute-injection payload', () => {
+    const payload = 'https://evil.tld" onmouseover="alert(1)" data-x="';
+    assert.ok(!utils.escapeAttr(payload).includes('"'));
+  });
+
+  it('handles null/undefined', () => {
+    assert.equal(utils.escapeAttr(null), '');
+    assert.equal(utils.escapeAttr(undefined), '');
+  });
+});
+
+describe('safeHttpUrl', () => {
+  it('accepts plain http(s) URLs', () => {
+    assert.equal(utils.safeHttpUrl('https://netlify.com/x'), 'https://netlify.com/x');
+    assert.equal(utils.safeHttpUrl('http://example.com'), 'http://example.com');
+  });
+
+  it('rejects URLs with quotes, whitespace, or angle brackets', () => {
+    assert.equal(utils.safeHttpUrl('https://evil.tld" onmouseover="alert(1)'), '');
+    assert.equal(utils.safeHttpUrl('https://a b.com'), '');
+    assert.equal(utils.safeHttpUrl('https://a<b>.com'), '');
+  });
+
+  it('rejects non-http(s) schemes', () => {
+    assert.equal(utils.safeHttpUrl('javascript:alert(1)'), '');
+    assert.equal(utils.safeHttpUrl('data:text/html,foo'), '');
+    assert.equal(utils.safeHttpUrl('file:///etc/passwd'), '');
+  });
+
+  it('handles empty input', () => {
+    assert.equal(utils.safeHttpUrl(''), '');
+    assert.equal(utils.safeHttpUrl(null), '');
+  });
+});
+
+describe('escapeMarkdownLinks', () => {
+  it('escapes [ so [label](url) cannot form', () => {
+    assert.equal(utils.escapeMarkdownLinks('[click](https://evil.tld)'), '\\[click](https://evil.tld)');
+  });
+
+  it('leaves prose without brackets unchanged', () => {
+    assert.equal(utils.escapeMarkdownLinks('Result complete.'), 'Result complete.');
+  });
+});


### PR DESCRIPTION
## Summary

Closes the markdown/HTML injection paths flagged in #16. Comment generators were splicing untrusted strings directly into raw HTML attributes and into markdown prose, so attribute injection (`href="..." onmouseover="..." data-x="..."`) and link-form injection (`[click here](https://phish.tld)`) both went through cleanly. GitHub's sanitizer strips event handlers, but attribute injection still lands a `style=`-style attribute, and the markdown-link form is fully effective inside a comment authored by a trusted bot.

- Add `escapeAttr`, `safeHttpUrl`, and `escapeMarkdownLinks` helpers to `src/utils.js`.
- Apply URL allowlist + attribute escape to every `<a href><img src>` site in the four comment generators (`result`, `success`, `status`, `history`).
- Apply markdown-link escape to agent-controlled `title` / `result` prose at each interpolation site.
- 9 new test cases including the exact issue #16 payload and scheme allowlist.

No new dependencies — we control the entire HTML template, so a 4-character attribute escape + URL regex is the right tool rather than pulling in DOMPurify + jsdom.

## Test plan

- [x] `npm test` — 299/299 pass locally (290 prior + 9 new)
- [ ] Canary run on this PR posts comments correctly with normal Netlify deploy/screenshot URLs (no false-positive URL rejection)
- [ ] Title/result text continues to render as expected; only `[` in agent prose becomes `\[`

Refs: #16