### PR TITLE
fix(action): surface Netlify PR creation errors

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1181,12 +1181,17 @@ runs:
 
                 PR_WAIT=0
                 PR_URL=""
+                PR_FAILURE=$(echo "$PR_API_RESULT" | jq -r '.pr_error // .error_message // .error // .message // empty' 2>/dev/null || true)
                 while [ $PR_WAIT -lt 60 ]; do
                   sleep 5
                   PR_WAIT=$((PR_WAIT + 5))
                   PR_CHECK=$(netlify api getAgentRunner --data "{\"agent_runner_id\": \"$AGENT_ID\"}" 2>/dev/null || true)
                   PR_URL=$(echo "$PR_CHECK" | jq -r '.pr_url // empty')
                   PR_CREATING=$(echo "$PR_CHECK" | jq -r '.pr_is_being_created // false')
+                  PR_ERROR=$(echo "$PR_CHECK" | jq -r '.pr_error // .error_message // .error // .message // empty' 2>/dev/null || true)
+                  if [ -n "$PR_ERROR" ]; then
+                    PR_FAILURE="$PR_ERROR"
+                  fi
                   if [ -n "$PR_URL" ]; then
                     echo "✅ PR created: $PR_URL"
                     echo "agent-pr-url=$PR_URL" >> $GITHUB_OUTPUT
@@ -1209,7 +1214,11 @@ runs:
                     break
                   fi
                   if [ "$PR_CREATING" = "false" ]; then
-                    echo "⚠️ PR creation finished but no URL returned"
+                    if [ -n "$PR_FAILURE" ]; then
+                      echo "⚠️ PR creation failed: $PR_FAILURE"
+                    else
+                      echo "⚠️ PR creation finished but no URL returned"
+                    fi
                     break
                   fi
                   echo "  [${PR_WAIT}/60s] Waiting for PR..."
@@ -1218,7 +1227,7 @@ runs:
                   echo "agent-pr-url=" >> $GITHUB_OUTPUT
                   echo "agent-pr-branch=" >> $GITHUB_OUTPUT
                   echo "outcome=failure" >> $GITHUB_OUTPUT
-                  emit_failure_context "create-pr" "pull-request-create-failed" "PR creation finished without a pull request URL"
+                  emit_failure_context "create-pr" "pull-request-create-failed" "${PR_FAILURE:-PR creation finished without a pull request URL}"
                   exit 1
                 fi
               else

--- a/src/action-wiring.test.js
+++ b/src/action-wiring.test.js
@@ -224,8 +224,10 @@ describe('action.yml wiring', () => {
 
   it('fails the run when post-agent commit or PR creation fails', () => {
     assert.match(actionYml, /COMMIT_FAILURE=""/);
+    assert.match(actionYml, /PR_FAILURE=\$\(echo "\$PR_API_RESULT" \| jq -r '.pr_error \/\/ .error_message \/\/ .error \/\/ .message \/\/ empty'/);
+    assert.match(actionYml, /PR_ERROR=\$\(echo "\$PR_CHECK" \| jq -r '.pr_error \/\/ .error_message \/\/ .error \/\/ .message \/\/ empty'/);
     assert.match(actionYml, /emit_failure_context "commit" "commit-to-branch-failed"/);
-    assert.match(actionYml, /emit_failure_context "create-pr" "pull-request-create-failed"/);
+    assert.match(actionYml, /emit_failure_context "create-pr" "pull-request-create-failed" "\$\{PR_FAILURE:-PR creation finished without a pull request URL\}"/);
     assert.match(actionYml, /echo "outcome=failure" >> \$GITHUB_OUTPUT/);
   });
 

--- a/src/failure-taxonomy.js
+++ b/src/failure-taxonomy.js
@@ -231,8 +231,9 @@ const FAILURE_TAXONOMY = Object.freeze({
     title: 'Failed to create pull request',
     summary: 'The agent produced diffs but a pull request URL was not created.',
     remediation: [
-      'Confirm repository `pull-requests: write` permission is granted.',
-      'Retry and inspect PR creation API responses in workflow logs.',
+      'Inspect the Netlify PR error in the result comment or workflow logs.',
+      'If the diff touches `.github/workflows`, grant the Netlify GitHub App workflow-file permission or land that workflow change manually.',
+      'Retry after resolving repository permission or branch protection constraints.',
     ],
     severity: 'error',
     retryable: true,

--- a/src/generate-result-comment.test.js
+++ b/src/generate-result-comment.test.js
@@ -137,6 +137,32 @@ describe('renderResultComment', () => {
     assert.ok(rendered.resultBody.includes(`<!-- ${RESULT_COMMENT_MARKER_NAME} `));
   });
 
+  it('surfaces Netlify PR errors in failure result comments', () => {
+    writeSessions('runner_pr_error', [{
+      id: 'session_pr_error',
+      prompt: '@netlify update workflow',
+      title: 'Update workflow',
+      agent_config: { agent: 'codex' },
+    }]);
+
+    const rendered = renderResultComment({
+      context: context(),
+      outcome: 'failure',
+      env: {
+        RUNNER_TEMP: tempDir,
+        AGENT_ID: 'runner_pr_error',
+        SITE_NAME: 'site',
+        AGENT_ERROR: 'Cannot push changes to GitHub workflow files (.github/workflows/). The GitHub App does not have the workflows permission required to modify these files.',
+        FAILURE_CATEGORY: 'pull-request-create-failed',
+        FAILURE_STAGE: 'create-pr',
+        SESSION_DATA_MAP: '{}',
+      },
+    });
+
+    assert.ok(rendered.resultBody.includes('Cannot push changes to GitHub workflow files'));
+    assert.ok(rendered.resultBody.includes('grant the Netlify GitHub App workflow-file permission'));
+  });
+
   it('treats latest error sessions as failure results even without AGENT_ERROR', () => {
     writeSessions('runner_5', [{
       id: 'session_5',


### PR DESCRIPTION
## Summary
- preserve Netlify `pr_error` from PR creation and `getAgentRunner` polling
- emit the real PR creation failure in action outputs/result comments instead of only "no PR URL"
- update remediation for workflow-file permission failures and cover it with tests

## Context
Revenue Engine issue #202 produced diffs but failed PR materialization because the Netlify GitHub App could not push `.github/workflows/*` changes without workflow-file permission. The action hid that API error behind a generic missing-URL message.

## Validation
- `bun test src/*.test.js`
- `bunx tsc --noEmit`
- `bun src/check-docs-drift.js`