### PR TITLE
[codex] Tighten PR URL wait budget

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1245,6 +1245,7 @@ runs:
 
               elif [ "$HAS_DIFF" = "true" ] && [ -z "$EXISTING_PR" ]; then
                 PR_MAX_ATTEMPTS=3
+                PR_WAIT_SECONDS=20
                 PR_ATTEMPT=1
                 PR_WAIT=0
                 PR_URL=""
@@ -1263,7 +1264,8 @@ runs:
                   fi
 
                   PR_WAIT=0
-                  while [ "$PR_HARD_FAILURE" = "false" ] && [ $PR_WAIT -lt 60 ]; do
+                  PR_CREATING=""
+                  while [ "$PR_HARD_FAILURE" = "false" ] && [ $PR_WAIT -lt $PR_WAIT_SECONDS ]; do
                     sleep 5
                     PR_WAIT=$((PR_WAIT + 5))
                     PR_CHECK=$(netlify api getAgentRunner --data "{\"agent_runner_id\": \"$AGENT_ID\"}" 2>/dev/null || true)
@@ -1305,8 +1307,12 @@ runs:
                       fi
                       break
                     fi
-                    echo "  [${PR_WAIT}/60s] Waiting for PR..."
+                    echo "  [${PR_WAIT}/${PR_WAIT_SECONDS}s] Waiting for PR..."
                   done
+                  if [ -z "$PR_URL" ] && [ "$PR_HARD_FAILURE" = "false" ] && [ "$PR_CREATING" != "false" ] && [ $PR_WAIT -ge $PR_WAIT_SECONDS ]; then
+                    PR_FAILURE="Timed out waiting ${PR_WAIT_SECONDS}s for pull request URL on attempt ${PR_ATTEMPT}"
+                    echo "⚠️ $PR_FAILURE"
+                  fi
 
                   if [ -n "$PR_URL" ]; then
                     break

--- a/src/action-wiring.test.js
+++ b/src/action-wiring.test.js
@@ -229,9 +229,11 @@ describe('action.yml wiring', () => {
     assert.match(actionYml, /cannot push changes to github workflow files/);
     assert.match(actionYml, /resource not accessible by integration/);
     assert.match(actionYml, /PR_MAX_ATTEMPTS=3/);
+    assert.match(actionYml, /PR_WAIT_SECONDS=20/);
     assert.match(actionYml, /Creating pull request \(attempt \$\{PR_ATTEMPT\}\/\$\{PR_MAX_ATTEMPTS\}\)/);
     assert.match(actionYml, /PR_FAILURE=\$\(echo "\$PR_API_RESULT" \| jq -r '.pr_error \/\/ .error_message \/\/ .error \/\/ .message \/\/ empty'/);
     assert.match(actionYml, /PR_ERROR=\$\(echo "\$PR_CHECK" \| jq -r '.pr_error \/\/ .error_message \/\/ .error \/\/ .message \/\/ empty'/);
+    assert.match(actionYml, /Timed out waiting \$\{PR_WAIT_SECONDS\}s for pull request URL on attempt \$\{PR_ATTEMPT\}/);
     assert.match(actionYml, /Retrying PR creation in \$\{PR_BACKOFF\}s/);
     assert.match(actionYml, /non-retryable error/);
     assert.match(actionYml, /emit_failure_context "commit" "commit-to-branch-failed"/);


### PR DESCRIPTION
## Summary
- reduce the per-attempt PR URL polling window from 60s to 20s
- keep the existing 3 PR creation attempts and backoff behavior
- make the PR URL timeout message explicit when the backend has not returned a URL yet

## Why
A recent revenue-engine agent run completed successfully in Netlify, but the GitHub Action failed after waiting too long across three 60s PR URL polling windows. Tightening this loop fails faster when the backend has not surfaced a PR URL and avoids implying PR creation definitively finished while it may still be pending.

## Validation
- `bun test src/*.test.js` passes: 301 pass / 0 fail
